### PR TITLE
Add support for optional address, name and url of location

### DIFF
--- a/src/WhatsApp/Content.cs
+++ b/src/WhatsApp/Content.cs
@@ -70,7 +70,10 @@ public record Location(double Latitude, double Longitude);
 /// Content contains a location.
 /// </summary>
 /// <param name="Location">The location provided as content.</param>
-public record LocationContent(Location Location) : Content
+/// <param name="Address">Optional address of the shared location.</param>
+/// <param name="Name">Optional name of the shared location.</param>
+/// <param name="Url">Optional URL of the shared location.</param>
+public record LocationContent(Location Location, string? Address, string? Name, string? Url) : Content
 {
     /// <inheritdoc/>
     public override ContentType Type => ContentType.Location;

--- a/src/WhatsApp/ContentMessage.cs
+++ b/src/WhatsApp/ContentMessage.cs
@@ -53,7 +53,13 @@ public record ContentMessage(string Id, Service To, User From, long Timestamp, C
                 }
                 elif $type == "location" then {
                     "$type": $type,
-                    location: .location,
+                    location: {
+                     latitude: .location.latitude,
+                     longitude: .location.longitude   
+                    },
+                    address: .location.address,
+                    name: .location.name,
+                    url: .location.url
                 }
                 elif $type == "image" or $type == "video" or $type == "audio" then {
                     "$type": $type,


### PR DESCRIPTION
We still keep Location as lat+long, since that's required and guaranteed to exist. The others are optional values in the payload.