### PR TITLE
Fix typo in SendAsync, add ReplyAsync and message-based overloads

### DIFF
--- a/WhatsApp.sln
+++ b/WhatsApp.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "src\Tests\Tests.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "src\Sample\Sample.csproj", "{37A61B10-BE1C-476D-81E0-2D0BCEAF3EE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysis", "src\CodeAnalysis\CodeAnalysis.csproj", "{63583965-B86B-485E-AACF-5C4E453B182E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{37A61B10-BE1C-476D-81E0-2D0BCEAF3EE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37A61B10-BE1C-476D-81E0-2D0BCEAF3EE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37A61B10-BE1C-476D-81E0-2D0BCEAF3EE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63583965-B86B-485E-AACF-5C4E453B182E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63583965-B86B-485E-AACF-5C4E453B182E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63583965-B86B-485E-AACF-5C4E453B182E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63583965-B86B-485E-AACF-5C4E453B182E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ builder.UseWhatsApp<IWhatsAppClient, ILogger<Program>>(async (client, logger, me
     logger.LogInformation($"Got message type {message.Type}");
     // Reply to an incoming content message, for example.
     if (message is ContentMessage content)
-        await client.SendTextAync(message.To.Id, message.From.Number, $"Got your {content.}");
+        await client.ReplyAsync(message, $"☑️ Got your {content.Content.Type}");
 }
 ```
 
@@ -86,10 +86,10 @@ common scenarios, such as reacting to a message and replying with plain text:
 ```csharp
 if (message is ContentMessage content)
 {
-    await client.ReactAsync(from: message.To.Id, to: message.From.Number, message.Id, "🧠");
+    await client.ReactAsync(message, "🧠");
     // simulate some hard work at hand, like doing some LLM-stuff :)
     await Task.Delay(2000);
-    await client.SendTextAync(message.To.Id, message.From.Number, $"☑️ Processed your {content.Type}");
+    await client.ReplyAsync(message, $"☑️ Got your {content.Content.Type}");
 }
 ```
 

--- a/src/CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CodeAnalysis/CodeAnalysis.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Devlooped.WhatsApp.CodeAnalysis</AssemblyName>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackFolder>analyzers/dotnet/cs</PackFolder>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\WhatsApp\IWhatsAppClient.cs" Link="IWhatsAppClient.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGetizer" Version="1.2.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/CodeAnalysis/Properties/launchSettings.json
+++ b/src/CodeAnalysis/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Roslyn": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\Tests\\Tests.csproj"
+    }
+  }
+}

--- a/src/CodeAnalysis/SendStringAnalyzer.cs
+++ b/src/CodeAnalysis/SendStringAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Devlooped.WhatsApp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class SendStringAnalyzer : DiagnosticAnalyzer
+{
+    public static DiagnosticDescriptor Rule { get; } = new(
+        id: "WA001",
+        title: "Invalid Payload Type",
+        messageFormat: $"The second parameter of '{nameof(IWhatsAppClient)}.{nameof(IWhatsAppClient.SendAsync)}' should not be a string.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        description: "The payload parameter is serialized and sent as JSON over HTTP. Use an object instead.",
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Name.Identifier.Text == nameof(IWhatsAppClient.SendAsync))
+        {
+            var methodSymbol = context.SemanticModel.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol;
+            if (methodSymbol?.ContainingSymbol.Name == nameof(IWhatsAppClient) && invocation.ArgumentList.Arguments.Count == 2)
+            {
+                var secondArgument = invocation.ArgumentList.Arguments[1];
+                var argumentType = context.SemanticModel.GetTypeInfo(secondArgument.Expression).Type;
+                if (argumentType?.SpecialType == SpecialType.System_String)
+                {
+                    var diagnostic = Diagnostic.Create(Rule, secondArgument.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/src/Sample/host.json
+++ b/src/Sample/host.json
@@ -12,6 +12,11 @@
         "excludedTypes": "Request"
       },
       "enableLiveMetricsFilters": true
+    },
+    "logLevel": {
+      "Microsoft": "Warning",
+      "System": "Warning",
+      "Devlooped": "Trace"
     }
   }
 }

--- a/src/Tests/AnalyzerExtensions.cs
+++ b/src/Tests/AnalyzerExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Devlooped.WhatsApp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Devlooped.WhatsApp;
+
+public static class AnalyzerExtensions
+{
+    public static TTest WithWhatsApp<TTest>(this TTest test) where TTest : AnalyzerTest<DefaultVerifier>
+    {
+        test.SolutionTransforms.Add((solution, projectId)
+            => solution
+                .GetProject(projectId)?
+                .AddMetadataReference(MetadataReference.CreateFromFile(typeof(IWhatsAppClient).Assembly.Location))
+                .Solution ?? solution);
+
+        return test;
+    }
+}

--- a/src/Tests/AnalyzerTests.cs
+++ b/src/Tests/AnalyzerTests.cs
@@ -1,0 +1,45 @@
+﻿extern alias CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Analyzer = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<CodeAnalysis.Devlooped.WhatsApp.SendStringAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<CodeAnalysis.Devlooped.WhatsApp.SendStringAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using SendStringAnalyzer = CodeAnalysis.Devlooped.WhatsApp.SendStringAnalyzer;
+
+namespace Devlooped.WhatsApp;
+
+public class AnalyzerTests
+{
+    [Fact]
+    public async Task InvalidSendTextAsync()
+    {
+        var test = new CSharpAnalyzerTest<SendStringAnalyzer, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                $$"""
+                using System.Threading.Tasks;
+                using {{nameof(Devlooped)}}.{{nameof(Devlooped.WhatsApp)}};
+                            
+                public class Handler
+                {
+                    public async Task Send({{nameof(IWhatsAppClient)}} client, string text)
+                    {
+                        await client.{{nameof(IWhatsAppClient.SendAsync)}}("1234", {|#0:text|});
+                    }
+                }
+                """
+        }.WithWhatsApp();
+
+        var expected = Analyzer.Diagnostic(SendStringAnalyzer.Rule).WithLocation(0);
+
+        test.ExpectedDiagnostics.Add(expected);
+
+        await test.RunAsync();
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
@@ -25,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WhatsApp\WhatsApp.csproj" />
+    <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" OutputItemType="Analyzer" Aliases="CodeAnalysis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/WhatsAppClientTests.cs
+++ b/src/Tests/WhatsAppClientTests.cs
@@ -21,7 +21,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
             VerifyToken = "asdf"
         }, MockLogger.Create<WhatsAppClient>());
 
-        var ex = await Assert.ThrowsAsync<ArgumentException>(() => client.SendAync("1234", new { }));
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() => client.SendAsync("1234", new { }));
 
         Assert.Equal("from", ex.ParamName);
     }
@@ -31,7 +31,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
     {
         var (configuration, client) = Initialize();
 
-        await client.SendTextAync(configuration["SendFrom"]!, configuration["SendTo"]!, "Hi there!");
+        await client.SendAync(configuration["SendFrom"]!, configuration["SendTo"]!, "Hi there!");
     }
 
     [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
@@ -41,7 +41,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
 
         // Send an interactive message with three buttons showcasing the payload/value 
         // being different than the button text
-        await client.SendAync(configuration["SendFrom"]!, new
+        await client.SendAsync(configuration["SendFrom"]!, new
         {
             messaging_product = "whatsapp",
             recipient_type = "individual",

--- a/src/WhatsApp/IWhatsAppClient.cs
+++ b/src/WhatsApp/IWhatsAppClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Devlooped.WhatsApp;
 
@@ -16,5 +17,6 @@ public interface IWhatsAppClient
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages"/>
     /// <exception cref="ArgumentException">The number <paramref name="from"/> is not registered in <see cref="MetaOptions"/>.</exception>
     /// <exception cref="HttpRequestException">The HTTP request failed. Exception message contains the error response body from WhatsApp.</exception>
-    Task SendAync(string from, object payload);
+    [Description(nameof(Devlooped) + nameof(WhatsApp) + nameof(IWhatsAppClient) + nameof(SendAsync))]
+    Task SendAsync(string from, object payload);
 }

--- a/src/WhatsApp/WhatsApp.csproj
+++ b/src/WhatsApp/WhatsApp.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
+
 </Project>

--- a/src/WhatsApp/WhatsAppClient.cs
+++ b/src/WhatsApp/WhatsAppClient.cs
@@ -30,7 +30,7 @@ public class WhatsAppClient(IHttpClientFactory httpFactory, IOptions<MetaOptions
         => new WhatsAppClient(httpFactory, Options.Create(options), logger);
 
     /// <inheritdoc />
-    public async Task SendAync(string from, object payload)
+    public async Task SendAsync(string from, object payload)
     {
         if (!options.Numbers.TryGetValue(from, out var token))
             throw new ArgumentException($"The number '{from}' is not registered in the options.", nameof(from));

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -3,19 +3,49 @@ using System.Threading.Tasks;
 
 namespace Devlooped.WhatsApp;
 
+/// <summary>
+/// Usability extensions for common messaging scenarios for WhatsApp.
+/// </summary>
 public static class WhatsAppClientExtensions
 {
+    /// <summary>
+    /// Marks the message as read. Happens automatically when the <see cref="AzureFunctions.Message(Microsoft.AspNetCore.Http.HttpRequest)"/> 
+    /// webhook endpoint is invoked with a message.
+    /// </summary>
+    public static Task MarkReadAsync(this IWhatsAppClient client, Message message)
+        => MarkReadAsync(client, message.To.Id, message.Id);
+
+    /// <summary>
+    /// Marks the message as read. Happens automatically when the <see cref="AzureFunctions.Message(Microsoft.AspNetCore.Http.HttpRequest)"/> 
+    /// webhook endpoint is invoked with a message.
+    /// </summary>
     public static Task MarkReadAsync(this IWhatsAppClient client, string from, string messageId)
-        => client.SendAync(from, new
+        => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
             status = "read",
             message_id = messageId,
         });
 
+    /// <summary>
+    /// Reacts to a message.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    /// <param name="message">The message to react to.</param>
+    /// <param name="reaction">The reaction emoji.</param>
+    public static Task ReactAsync(this IWhatsAppClient client, Message message, string reaction)
+        => ReactAsync(client, message.To.Id, message.From.Number, message.Id, reaction);
 
+    /// <summary>
+    /// Reacts to a message.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    /// <param name="from">The service number to send the reaction through.</param>
+    /// <param name="to">The user phone number to send the reaction to.</param>
+    /// <param name="messageId">The message identifier to react to.</param>
+    /// <param name="reaction">The reaction emoji.</param>
     public static Task ReactAsync(this IWhatsAppClient client, string from, string to, string messageId, string reaction)
-        => client.SendAync(from, new
+        => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
             recipient_type = "individual",
@@ -28,8 +58,46 @@ public static class WhatsAppClientExtensions
             }
         });
 
-    public static Task SendTextAync(this IWhatsAppClient client, string from, string to, string message)
-        => client.SendAync(from, new
+    /// <summary>
+    /// Replies to a user message.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    /// <param name="message">The message to reply to.</param>
+    /// <param name="reply">The text message to respond with.</param>
+    public static Task ReplyAsync(this IWhatsAppClient client, Message message, string reply)
+        => client.SendAsync(message.To.Id, new
+        {
+            messaging_product = "whatsapp",
+            preview_url = false,
+            recipient_type = "individual",
+            to = NormalizeNumber(message.From.Number),
+            type = "text",
+            context = new
+            {
+                message_id = message.Id
+            },
+            text = new
+            {
+                body = reply
+            }
+        });
+
+    /// <summary>
+    /// Sends a text message a user given his incoming message, without making it a reply.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    public static Task SendAync(this IWhatsAppClient client, Message message, string text)
+        => SendAync(client, message.To.Id, message.From.Number, text);
+
+    /// <summary>
+    /// Sends a text message a user.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    /// <param name="from">The service number to send the message through.</param>
+    /// <param name="to">The user phone number to send the message to.</param>
+    /// <param name="message">The text message to send.</param>
+    public static Task SendAync(this IWhatsAppClient client, string from, string to, string message)
+        => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
             preview_url = false,


### PR DESCRIPTION
In most use cases, we'd have a Message from the user at hand. Therefore, it significantly simplifies things if we can just Reply/React/MarkRead/Send back to the sender of the message, so we add extension method overloads.

Also, since attempting to use SendAsync(number, "hello") is an obvious mistake that's too easy to make (the payload should be an object matching expected payloads from WhatsApp API), we add an analyzer that flags this as a compilation error so it can never happen. Ideally, we'd like to exclude a string from being acceptable as an `object`, but this is the next best thing :).