### PR TITLE
Add reaction message support, improve type safety

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -4,6 +4,7 @@
     <RootNamespace>Devlooped.WhatsApp</RootNamespace>
     <UserSecretsId>41fc668e-a410-48d4-9884-c2937478d9e1</UserSecretsId>
     <PackageLicenseExpression>AGPL-3.0-or-later WITH Universal-FOSS-exception-1.0</PackageLicenseExpression>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Tests/Content/WhatsApp/Reaction.json
+++ b/src/Tests/Content/WhatsApp/Reaction.json
@@ -1,0 +1,38 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "123456789012345",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "5491234567890",
+              "phone_number_id": "987654321098765"
+            },
+            "contacts": [
+              {
+                "profile": { "name": "RandomName" },
+                "wa_id": "5499876543210"
+              }
+            ],
+            "messages": [
+              {
+                "from": "5499876543210",
+                "id": "wamid.HBgNMTIzNDU2Nzg5MDEyMzQ1MhUCABEYEkY5QzQxNDNBQjgyRkVENEIzMQA=",
+                "timestamp": "1744229999",
+                "type": "reaction",
+                "reaction": {
+                  "message_id": "wamid.HBgNMTIzNDU2Nzg5MDEyMzQ1MhUCABEYEkY5QzQxNDNBQjgyRkVENEIzMQA=",
+                  "emoji": "😊"
+                }
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/Content/WhatsApp/StatusDelivered.json
+++ b/src/Tests/Content/WhatsApp/StatusDelivered.json
@@ -1,0 +1,37 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "918273645102347",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "1209384756109",
+              "phone_number_id": "739102584617293"
+            },
+            "statuses": [
+              {
+                "id": "wamid.HBgMMTIwMzQ1Njc4OTAxNxUCABEYEjZFNzI5QzFDNkE5RDg3MjBBNwA=",
+                "status": "sent",
+                "timestamp": "1829471036",
+                "recipient_id": "1203456789012",
+                "conversation": {
+                  "id": "4a7b9c2d8e5f0136pqr890xy12mn3op",
+                  "origin": { "type": "utility" }
+                },
+                "pricing": {
+                  "billable": false,
+                  "pricing_model": "NBP",
+                  "category": "utility"
+                }
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/Content/WhatsApp/Text.json
+++ b/src/Tests/Content/WhatsApp/Text.json
@@ -19,6 +19,10 @@
             ],
             "messages": [
               {
+                "context": {
+                  "from": "12025550123",
+                  "id": "wamid.HBgNNTQ5MTE1OTL4ODI4MhUCBBEYEjUxNDI3NkMzRkI1ODVCRTgwOAA="
+                },
                 "from": "12029874563",
                 "id": "wamid.HBgNMTIwMjk4NzQ1NjM1NhUCABIYFjQ5RjE4QzJEMzU2ODk3QTJFMUY3RDEyMjNBNkI5QwA==",
                 "timestamp": "1678902345",

--- a/src/Tests/WhatsAppClientTests.cs
+++ b/src/Tests/WhatsAppClientTests.cs
@@ -31,7 +31,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
     {
         var (configuration, client) = Initialize();
 
-        await client.SendAync(configuration["SendFrom"]!, configuration["SendTo"]!, "Hi there!");
+        await client.SendAsync(configuration["SendFrom"]!, configuration["SendTo"]!, "Hi there!");
     }
 
     [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]

--- a/src/WhatsApp/ContentMessage.cs
+++ b/src/WhatsApp/ContentMessage.cs
@@ -10,7 +10,7 @@ namespace Devlooped.WhatsApp;
 /// <param name="From">The user that sent the message.</param>
 /// <param name="Timestamp">Timestamp of the message.</param>
 /// <param name="Content">Message content.</param>
-public record ContentMessage(string Id, Service To, User From, long Timestamp, Content Content) : Message(Id, To, From, Timestamp)
+public record ContentMessage(string Id, Service To, User From, long Timestamp, Content Content) : UserMessage(Id, To, From, Timestamp)
 {
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/WhatsApp/ErrorMessage.cs
+++ b/src/WhatsApp/ErrorMessage.cs
@@ -10,7 +10,7 @@ namespace Devlooped.WhatsApp;
 /// <param name="From">The user that sent the message.</param>
 /// <param name="Timestamp">Timestamp of the message.</param>
 /// <param name="Error">The error.</param>
-public record ErrorMessage(string Id, Service To, User From, long Timestamp, Error Error) : Message(Id, To, From, Timestamp)
+public record ErrorMessage(string Id, Service To, User From, long Timestamp, Error Error) : SystemMessage(Id, To, From, Timestamp)
 {
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/WhatsApp/InteractiveMessage.cs
+++ b/src/WhatsApp/InteractiveMessage.cs
@@ -10,7 +10,7 @@ namespace Devlooped.WhatsApp;
 /// <param name="From">The user that sent the message.</param>
 /// <param name="Timestamp">Timestamp of the message.</param>
 /// <param name="Button">The button selected by the user.</param>
-public record InteractiveMessage(string Id, Service To, User From, long Timestamp, Button Button) : Message(Id, To, From, Timestamp)
+public record InteractiveMessage(string Id, Service To, User From, long Timestamp, Button Button) : UserMessage(Id, To, From, Timestamp)
 {
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/WhatsApp/MessageType.cs
+++ b/src/WhatsApp/MessageType.cs
@@ -18,6 +18,10 @@ public enum MessageType
     /// </summary>
     Interactive,
     /// <summary>
+    /// Message contains a reaction to a message.
+    /// </summary>
+    Reaction,
+    /// <summary>
     /// Message contains a status update.
     /// </summary>
     Status,

--- a/src/WhatsApp/ReactionMessage.cs
+++ b/src/WhatsApp/ReactionMessage.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Devlooped.WhatsApp;
+
+/// <summary>
+/// A reaction to a message.
+/// </summary>
+/// <param name="Id">The identifier of the message this reaction applies to.</param>
+/// <param name="To">The service that received the message from the Cloud API.</param>
+/// <param name="From">The user that sent the message.</param>
+/// <param name="Timestamp">Timestamp of the message.</param>
+/// <param name="Emoji">The emoji of the reaction.</param>
+public record ReactionMessage(string Id, Service To, User From, long Timestamp, string Emoji) : SystemMessage(Id, To, From, Timestamp)
+{
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public override MessageType Type => MessageType.Reaction;
+}

--- a/src/WhatsApp/StatusMessage.cs
+++ b/src/WhatsApp/StatusMessage.cs
@@ -3,23 +3,35 @@
 namespace Devlooped.WhatsApp;
 
 /// <summary>
-/// A <see cref="Message"/> containing a status update.
+/// A status update about a message.
 /// </summary>
-/// <param name="Id">The message identifier.</param>
+/// <param name="Id">The identifier of the message this status update relates to.</param>
 /// <param name="To">The service that received the message from the Cloud API.</param>
 /// <param name="From">The user that sent the message.</param>
 /// <param name="Timestamp">Timestamp of the message.</param>
 /// <param name="Status">The message status.</param>
-public record StatusMessage(string Id, Service To, User From, long Timestamp, Status Status) : Message(Id, To, From, Timestamp)
+public record StatusMessage(string Id, Service To, User From, long Timestamp, Status Status) : SystemMessage(Id, To, From, Timestamp)
 {
     /// <inheritdoc/>
     [JsonIgnore]
     public override MessageType Type => MessageType.Status;
 }
 
+/// <summary>
+/// Known statuses for a message.
+/// </summary>
 public enum Status
 {
+    /// <summary>
+    /// The message was sent.
+    /// </summary>
     Sent,
+    /// <summary>
+    /// The message was delivered.
+    /// </summary>
     Delivered,
+    /// <summary>
+    /// The message was read.
+    /// </summary>
     Read,
 }

--- a/src/WhatsApp/SystemMessage.cs
+++ b/src/WhatsApp/SystemMessage.cs
@@ -1,0 +1,10 @@
+﻿namespace Devlooped.WhatsApp;
+
+/// <summary>
+/// Base message class for messages that cannot be interacted with by the user.
+/// </summary>
+/// <param name="Id">The message identifier.</param>
+/// <param name="To">The service that received the message from the Cloud API.</param>
+/// <param name="From">The user that sent the message.</param>
+/// <param name="Timestamp">Timestamp of the message.</param>
+public abstract record SystemMessage(string Id, Service To, User From, long Timestamp) : Message(Id, To, From, Timestamp);

--- a/src/WhatsApp/UnsupportedMessage.cs
+++ b/src/WhatsApp/UnsupportedMessage.cs
@@ -12,7 +12,7 @@ namespace Devlooped.WhatsApp;
 /// <param name="From">The user that sent the message.</param>
 /// <param name="Timestamp">Timestamp of the message.</param>
 /// <param name="Raw">JSON data.</param>
-public record UnsupportedMessage(string Id, Service To, User From, long Timestamp, JsonElement Raw) : Message(Id, To, From, Timestamp)
+public record UnsupportedMessage(string Id, Service To, User From, long Timestamp, JsonElement Raw) : SystemMessage(Id, To, From, Timestamp)
 {
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/WhatsApp/UserMessage.cs
+++ b/src/WhatsApp/UserMessage.cs
@@ -1,0 +1,10 @@
+﻿namespace Devlooped.WhatsApp;
+
+/// <summary>
+/// Base message class for messages the user can interact with.
+/// </summary>
+/// <param name="Id">The message identifier.</param>
+/// <param name="To">The service that received the message from the Cloud API.</param>
+/// <param name="From">The user that sent the message.</param>
+/// <param name="Timestamp">Timestamp of the message.</param>
+public abstract record UserMessage(string Id, Service To, User From, long Timestamp) : Message(Id, To, From, Timestamp);

--- a/src/WhatsApp/WhatsApp.csproj
+++ b/src/WhatsApp/WhatsApp.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Devlooped.WhatsApp;
+﻿namespace Devlooped.WhatsApp;
 
 /// <summary>
 /// Usability extensions for common messaging scenarios for WhatsApp.
@@ -12,7 +9,7 @@ public static class WhatsAppClientExtensions
     /// Marks the message as read. Happens automatically when the <see cref="AzureFunctions.Message(Microsoft.AspNetCore.Http.HttpRequest)"/> 
     /// webhook endpoint is invoked with a message.
     /// </summary>
-    public static Task MarkReadAsync(this IWhatsAppClient client, Message message)
+    public static Task MarkReadAsync(this IWhatsAppClient client, UserMessage message)
         => MarkReadAsync(client, message.To.Id, message.Id);
 
     /// <summary>
@@ -32,9 +29,9 @@ public static class WhatsAppClientExtensions
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
     /// <param name="message">The message to react to.</param>
-    /// <param name="reaction">The reaction emoji.</param>
-    public static Task ReactAsync(this IWhatsAppClient client, Message message, string reaction)
-        => ReactAsync(client, message.To.Id, message.From.Number, message.Id, reaction);
+    /// <param name="emoji">The reaction emoji.</param>
+    public static Task ReactAsync(this IWhatsAppClient client, UserMessage message, string emoji)
+        => ReactAsync(client, message.To.Id, message.From.Number, message.Id, emoji);
 
     /// <summary>
     /// Reacts to a message.
@@ -43,8 +40,8 @@ public static class WhatsAppClientExtensions
     /// <param name="from">The service number to send the reaction through.</param>
     /// <param name="to">The user phone number to send the reaction to.</param>
     /// <param name="messageId">The message identifier to react to.</param>
-    /// <param name="reaction">The reaction emoji.</param>
-    public static Task ReactAsync(this IWhatsAppClient client, string from, string to, string messageId, string reaction)
+    /// <param name="emoji">The reaction emoji.</param>
+    public static Task ReactAsync(this IWhatsAppClient client, string from, string to, string messageId, string emoji)
         => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
@@ -54,7 +51,7 @@ public static class WhatsAppClientExtensions
             reaction = new
             {
                 message_id = messageId,
-                emoji = reaction
+                emoji
             }
         });
 
@@ -64,7 +61,7 @@ public static class WhatsAppClientExtensions
     /// <param name="client">The WhatsApp client.</param>
     /// <param name="message">The message to reply to.</param>
     /// <param name="reply">The text message to respond with.</param>
-    public static Task ReplyAsync(this IWhatsAppClient client, Message message, string reply)
+    public static Task ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply)
         => client.SendAsync(message.To.Id, new
         {
             messaging_product = "whatsapp",
@@ -83,11 +80,35 @@ public static class WhatsAppClientExtensions
         });
 
     /// <summary>
+    /// Replies to the message a user reacted to.
+    /// </summary>
+    /// <param name="client">The WhatsApp client.</param>
+    /// <param name="reaction">The reaction from the user.</param>
+    /// <param name="reply">The text message to respond with.</param>
+    public static Task ReplyAsync(this IWhatsAppClient client, ReactionMessage message, string reply)
+        => client.SendAsync(message.To.Id, new
+        {
+            messaging_product = "whatsapp",
+            preview_url = false,
+            recipient_type = "individual",
+            to = NormalizeNumber(message.From.Number),
+            type = "text",
+            context = new
+            {
+                message_id = message.Context
+            },
+            text = new
+            {
+                body = reply
+            }
+        });
+
+    /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    public static Task SendAync(this IWhatsAppClient client, Message message, string text)
-        => SendAync(client, message.To.Id, message.From.Number, text);
+    public static Task SendAsync(this IWhatsAppClient client, Message message, string text)
+        => SendAsync(client, message.To.Id, message.From.Number, text);
 
     /// <summary>
     /// Sends a text message a user.
@@ -96,7 +117,7 @@ public static class WhatsAppClientExtensions
     /// <param name="from">The service number to send the message through.</param>
     /// <param name="to">The user phone number to send the message to.</param>
     /// <param name="message">The text message to send.</param>
-    public static Task SendAync(this IWhatsAppClient client, string from, string to, string message)
+    public static Task SendAsync(this IWhatsAppClient client, string from, string to, string message)
         => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
@@ -113,6 +134,5 @@ public static class WhatsAppClientExtensions
     static string NormalizeNumber(string number) =>
         // On the web, we don't get the 9 after 54 \o/
         // so for Argentina numbers, we need to remove the 9.
-        number.StartsWith("549", StringComparison.Ordinal) ?
-                "54" + number[3..] : number;
+        number.StartsWith("549", StringComparison.Ordinal) ? "54" + number[3..] : number;
 }


### PR DESCRIPTION
We were not surfacing reaction messages separately. This now allows processing user reactions separately from other message types.

Also, type safety when doing Reply and MarkRead wasn't great since users could attempt either operation on a message that doesn't support that kind of interaction (such as status or error messages). So we create two intermediate types, UserMessage (the ones users can interact with, like content and interactive messages), and SystemMessage (reaction, status, error and unsupported).

We also fix the sample to properly report the environment which for some reason is not Development despite envvars being set properly by the Azure Functions tools on local run.