### PR TITLE
Fix NRE when marking message read

### DIFF
--- a/src/WhatsApp/WhatsAppClient.cs
+++ b/src/WhatsApp/WhatsAppClient.cs
@@ -62,6 +62,6 @@ public class WhatsAppClient(IHttpClientFactory httpFactory, IOptions<MetaOptions
 
         var response = await result.Content.ReadFromJsonAsync(WhatsAppSerializerContext.Default.SendResponse);
 
-        return response?.Messages.FirstOrDefault()?.Id;
+        return response?.Messages?.FirstOrDefault()?.Id;
     }
 }


### PR DESCRIPTION
There's no messages in this case, even though the response can be deserialized. So add a null-propagating ? on Messages too.