### PR TITLE
Shorten name of extensions class

### DIFF
--- a/src/WhatsApp/LoggingHandlerExtensions.cs
+++ b/src/WhatsApp/LoggingHandlerExtensions.cs
@@ -7,7 +7,7 @@ namespace Devlooped.WhatsApp;
 /// <summary>
 /// Provides extensions for configuring <see cref="LoggingHandler"/> instances.
 /// </summary>
-public static class LoggingHandlerBuilderExtensions
+public static class LoggingHandlerExtensions
 {
     /// <summary>
     /// Adds a logging handler to the pipeline.


### PR DESCRIPTION
We only have builder extensions, so just make it shorter.