### PR TITLE
Make handlers receive multiple messages instead of one

### DIFF
--- a/src/Tests/WhatsAppHandlerExtensions.cs
+++ b/src/Tests/WhatsAppHandlerExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Devlooped.WhatsApp;
+
+public static class WhatsAppHandlerExtensions
+{
+    public static Task HandleAsync(this IWhatsAppHandler handler, Message message, CancellationToken cancellation = default)
+        => handler.HandleAsync([message], cancellation);
+}

--- a/src/WhatsApp/AnonymousDelegatingHandler.cs
+++ b/src/WhatsApp/AnonymousDelegatingHandler.cs
@@ -5,7 +5,7 @@ namespace Devlooped.WhatsApp;
 class AnonymousDelegatingHandler : DelegatingHandler
 {
     /// <summary>The delegate to use as the implementation of <see cref="Handle"/>.</summary>
-    readonly Func<Message, IWhatsAppHandler, CancellationToken, Task> handlerFunc;
+    readonly Func<IEnumerable<Message>, IWhatsAppHandler, CancellationToken, Task> handlerFunc;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AnonymousDelegatingChatClient"/> class.
@@ -14,9 +14,9 @@ class AnonymousDelegatingHandler : DelegatingHandler
     /// <param name="handlerFunc">A delegate that provides the implementation for <see cref="HandleAsync"/></param>
     public AnonymousDelegatingHandler(
         IWhatsAppHandler innerHandler,
-        Func<Message, IWhatsAppHandler, CancellationToken, Task> handlerFunc) : base(innerHandler)
+        Func<IEnumerable<Message>, IWhatsAppHandler, CancellationToken, Task> handlerFunc) : base(innerHandler)
         => this.handlerFunc = Throw.IfNull(handlerFunc);
 
-    public override Task HandleAsync(Message message, CancellationToken cancellation = default)
-        => handlerFunc(message, InnerHandler, cancellation);
+    public override Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default)
+        => handlerFunc(messages, InnerHandler, cancellation);
 }

--- a/src/WhatsApp/AzureFunctions.cs
+++ b/src/WhatsApp/AzureFunctions.cs
@@ -90,7 +90,7 @@ public class AzureFunctions(
                 return;
             }
 
-            await handler.HandleAsync(message);
+            await handler.HandleAsync([message]);
             await table.UpsertEntityAsync(new TableEntity(message.From.Number, message.Id));
             logger.LogInformation($"Completed work item: {message.Id}");
         }

--- a/src/WhatsApp/AzureFunctionsExtensions.cs
+++ b/src/WhatsApp/AzureFunctionsExtensions.cs
@@ -77,7 +77,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp(this IFunctionsWorkerApplicationBuilder builder, Func<IServiceProvider, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp(this IFunctionsWorkerApplicationBuilder builder, Func<IServiceProvider, IEnumerable<Message>, CancellationToken, Task> handler)
     {
         builder.Services.AddSingleton<IWhatsAppHandler>(services => new AnonymousWhatsAppHandler(services, handler));
         ConfigureServices(builder.Services);
@@ -87,7 +87,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp(this IFunctionsWorkerApplicationBuilder builder, Func<Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp(this IFunctionsWorkerApplicationBuilder builder, Func<IEnumerable<Message>, CancellationToken, Task> handler)
     {
         builder.Services.AddSingleton<IWhatsAppHandler>(services => new SimpleAnonymousWhatsAppHandler(handler));
         ConfigureServices(builder.Services);
@@ -97,7 +97,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService>(this IFunctionsWorkerApplicationBuilder builder, Func<TService, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService>(this IFunctionsWorkerApplicationBuilder builder, Func<TService, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService : notnull
     {
         builder.Services.AddSingleton<IWhatsAppHandler>(services => new AnonymousWhatsAppHandler<TService>(services.GetRequiredService<TService>(), handler));
@@ -108,7 +108,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService1 : notnull
         where TService2 : notnull
     {
@@ -120,7 +120,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService1 : notnull
         where TService2 : notnull
         where TService3 : notnull
@@ -133,7 +133,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService1 : notnull
         where TService2 : notnull
         where TService3 : notnull
@@ -147,7 +147,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4, TService5>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, TService5, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4, TService5>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, TService5, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService1 : notnull
         where TService2 : notnull
         where TService3 : notnull
@@ -162,7 +162,7 @@ public static class AzureFunctionsExtensions
     /// <summary>
     /// Configure the WhatsApp handler for Azure Functions.
     /// </summary>
-    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4, TService5, TService6>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, TService5, TService6, Message, CancellationToken, Task> handler)
+    public static IFunctionsWorkerApplicationBuilder UseWhatsApp<TService1, TService2, TService3, TService4, TService5, TService6>(this IFunctionsWorkerApplicationBuilder builder, Func<TService1, TService2, TService3, TService4, TService5, TService6, IEnumerable<Message>, CancellationToken, Task> handler)
         where TService1 : notnull
         where TService2 : notnull
         where TService3 : notnull
@@ -175,43 +175,43 @@ public static class AzureFunctionsExtensions
         return builder;
     }
 
-    class SimpleAnonymousWhatsAppHandler(Func<Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class SimpleAnonymousWhatsAppHandler(Func<IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler(IServiceProvider services, Func<IServiceProvider, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler(IServiceProvider services, Func<IServiceProvider, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(services, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(services, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService>(TService service, Func<TService, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService>(TService service, Func<TService, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService1, TService2>(TService1 service1, TService2 service2, Func<TService1, TService2, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService1, TService2>(TService1 service1, TService2 service2, Func<TService1, TService2, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service1, service2, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service1, service2, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService1, TService2, TService3>(TService1 service1, TService2 service2, TService3 service3, Func<TService1, TService2, TService3, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService1, TService2, TService3>(TService1 service1, TService2 service2, TService3 service3, Func<TService1, TService2, TService3, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service1, service2, service3, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service1, service2, service3, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, Func<TService1, TService2, TService3, TService4, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, Func<TService1, TService2, TService3, TService4, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4, TService5>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, TService5 service5, Func<TService1, TService2, TService3, TService4, TService5, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4, TService5>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, TService5 service5, Func<TService1, TService2, TService3, TService4, TService5, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, service5, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, service5, messages, cancellation);
     }
 
-    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4, TService5, TService6>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, TService5 service5, TService6 service6, Func<TService1, TService2, TService3, TService4, TService5, TService6, Message, CancellationToken, Task> handler) : IWhatsAppHandler
+    class AnonymousWhatsAppHandler<TService1, TService2, TService3, TService4, TService5, TService6>(TService1 service1, TService2 service2, TService3 service3, TService4 service4, TService5 service5, TService6 service6, Func<TService1, TService2, TService3, TService4, TService5, TService6, IEnumerable<Message>, CancellationToken, Task> handler) : IWhatsAppHandler
     {
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, service5, service6, message, cancellation);
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => handler(service1, service2, service3, service4, service5, service6, messages, cancellation);
     }
 }

--- a/src/WhatsApp/DelegatingHandler.cs
+++ b/src/WhatsApp/DelegatingHandler.cs
@@ -27,7 +27,7 @@ public class DelegatingHandler : IWhatsAppHandler, IDisposable
     }
 
     /// <inheritdoc />
-    public virtual Task HandleAsync(Message message, CancellationToken cancellation = default) => InnerHandler.HandleAsync(message, cancellation);
+    public virtual Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => InnerHandler.HandleAsync(messages, cancellation);
 
     /// <summary>Provides a mechanism for releasing unmanaged resources.</summary>
     /// <param name="disposing"><see langword="true"/> if being called from <see cref="Dispose()"/>; otherwise, <see langword="false"/>.</param>

--- a/src/WhatsApp/IWhatsAppHandler.cs
+++ b/src/WhatsApp/IWhatsAppHandler.cs
@@ -6,9 +6,9 @@
 public interface IWhatsAppHandler
 {
     /// <summary>
-    /// Handles the incoming message from WhatsApp.
+    /// Handles the incoming message(s) from WhatsApp.
     /// </summary>
-    /// <param name="message">The received message.</param>
+    /// <param name="messages">The received message(s).</param>
     /// <remarks>
     /// If this method throws, it will be retried up to the max dequeue count. The default 
     /// is 5, and can be configured in <c>host.json</c> as follows:
@@ -25,5 +25,5 @@ public interface IWhatsAppHandler
     /// After the max dequeue retries, the message will be moved to the <c>whatsapp-poison</c> 
     /// queue.
     /// </remarks>
-    Task HandleAsync(Message message, CancellationToken cancellation = default);
+    Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default);
 }

--- a/src/WhatsApp/LoggingHandler.cs
+++ b/src/WhatsApp/LoggingHandler.cs
@@ -14,19 +14,19 @@ public partial class LoggingHandler(IWhatsAppHandler innerHandler, ILogger logge
         set => options = Throw.IfNull(value);
     }
 
-    public override async Task HandleAsync(Message message, CancellationToken cancellation = default)
+    public override async Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default)
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
             if (logger.IsEnabled(LogLevel.Trace))
-                LogInvokedSensitive(nameof(HandleAsync), AsJson(message, options));
+                LogInvokedSensitive(nameof(HandleAsync), AsJson(messages, options));
             else
                 LogInvoked(nameof(HandleAsync));
         }
 
         try
         {
-            await base.HandleAsync(message, cancellation);
+            await base.HandleAsync(messages, cancellation);
             if (logger.IsEnabled(LogLevel.Debug))
                 LogCompleted(nameof(HandleAsync));
         }

--- a/src/WhatsApp/WhatsAppHandlerBuilder.cs
+++ b/src/WhatsApp/WhatsAppHandlerBuilder.cs
@@ -62,7 +62,7 @@ public class WhatsAppHandlerBuilder
     /// need to interact with the results of the operation, which will come from the inner client.
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="handlerFunc"/> is <see langword="null"/>.</exception>
-    public WhatsAppHandlerBuilder Use(Func<Message, IWhatsAppHandler, CancellationToken, Task> handlerFunc)
+    public WhatsAppHandlerBuilder Use(Func<IEnumerable<Message>, IWhatsAppHandler, CancellationToken, Task> handlerFunc)
     {
         _ = Throw.IfNull(handlerFunc);
 
@@ -75,7 +75,7 @@ public class WhatsAppHandlerBuilder
 
         EmptyHandler() { }
 
-        public Task HandleAsync(Message message, CancellationToken cancellation = default) => Task.CompletedTask;
+        public Task HandleAsync(IEnumerable<Message> messages, CancellationToken cancellation = default) => Task.CompletedTask;
     }
 
     class EmptyServiceProvider : IServiceProvider

--- a/src/WhatsApp/WhatsAppHandlerExtensions.cs
+++ b/src/WhatsApp/WhatsAppHandlerExtensions.cs
@@ -1,0 +1,5 @@
+﻿namespace Devlooped.WhatsApp;
+
+class WhatsAppHandlerExtensions
+{
+}


### PR DESCRIPTION
This is preparatory work to allow pipeline behaviors that can augment incoming (single) messages from the azure functions handler to (for example) load existing conversations from storage/cache, load replied-to messages, etc.