### PR TITLE
Generalize the former reengage as a general solution

### DIFF
--- a/src/SampleApp/Sample/Program.cs
+++ b/src/SampleApp/Sample/Program.cs
@@ -68,7 +68,8 @@ static async IAsyncEnumerable<Response> ProcessMessagesAsync(
         // Reengagement error, we need to invite the user.
         if (error.Error.Code == 131047)
         {
-            yield return error.Reengage();
+            // Showcases how to use a pre-declared template response to reengage the user.
+            yield return error.Template("reengagement", "es_AR");
         }
         else
         {

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -14,10 +14,21 @@ public static partial class MessageExtensions
         => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, emoji);
 
     /// <summary>
-    /// Creates a reengagement response for the error message.
+    /// Creates a simple template response for the message.
     /// </summary>
-    public static TemplateResponse Reengage(this ErrorMessage message)
-        => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, "reengagement", "es_AR");
+    public static TemplateResponse Template(this Message message, string name, string language)
+        => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, name, language);
+
+    /// <summary>
+    /// Creates a complex template response for the message.
+    /// </summary>
+    /// <param name="message">The message to respond to.</param>
+    /// <param name="template">The full template object as supported by the WhatsApp for Business API.</param>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages"/>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#components-object"/>
+    public static TemplateResponse Template(this Message message, object template)
+        => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, template);
 
     /// <summary>
     /// Creates a text response for the message.

--- a/src/WhatsApp/TemplateResponse.cs
+++ b/src/WhatsApp/TemplateResponse.cs
@@ -10,13 +10,20 @@
 /// <param name="Service">The identifier of the service handling the message.</param>
 /// <param name="Context">The unique identifier of the message to which the reaction is being sent.</param>
 /// <param name="Name">The template name</param>
-/// <param name="Code">The template lang code</param>
-public record TemplateResponse(string Number, string Service, string Context, string? ConversationId, string Name, string Code) : Response(Number, Service, Context, ConversationId)
+/// <param name="Language">The template language code (i.e. 'es_AR')</param>
+/// <see cref="https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages"/>
+/// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
+public record TemplateResponse(string Number, string Service, string Context, string? ConversationId, object Template) : Response(Number, Service, Context, ConversationId)
 {
+    public TemplateResponse(string Number, string Service, string Context, string? ConversationId, string Name, string Language)
+        : this(Number, Service, Context, ConversationId, new { name = Name, language = new { code = Language } })
+    {
+    }
+
     /// <inheritdoc/>
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellationToken = default)
     {
-        await client.SendTemplateAsync(Service, Number, Name, Code, cancellationToken);
+        await client.SendTemplateAsync(Service, Number, Template, cancellationToken);
 
         return Ulid.NewUlid().ToString();
     }

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -42,6 +42,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="client">The WhatsApp client.</param>
     /// <param name="message">The message to react to.</param>
     /// <param name="emoji">The reaction emoji.</param>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#reaction-object"/>
     public static Task ReactAsync(this IWhatsAppClient client, UserMessage message, string emoji, CancellationToken cancellationToken = default)
         => ReactAsync(client, message.To.Id, message.From.Number, message.Id, emoji, cancellationToken);
 
@@ -53,6 +54,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="to">The user phone number to send the reaction to.</param>
     /// <param name="messageId">The message identifier to react to.</param>
     /// <param name="emoji">The reaction emoji.</param>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#reaction-object"/>
     public static Task ReactAsync(this IWhatsAppClient client, string from, string to, string messageId, string emoji, CancellationToken cancellationToken = default)
         => client.SendAsync(from, new
         {
@@ -68,28 +70,24 @@ static partial class WhatsAppClientExtensions
         }, cancellationToken);
 
     /// <summary>
-    /// Reacts to a message.
+    /// Sends a template response to a message.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the reaction through.</param>
-    /// <param name="to">The user phone number to send the reaction to.</param>
-    /// <param name="messageId">The message identifier to react to.</param>
-    /// <param name="emoji">The reaction emoji.</param>
-    public static Task SendTemplateAsync(this IWhatsAppClient client, string from, string to, string templateName, string code, CancellationToken cancellationToken = default)
+    /// <param name="from">The service number to send the template through.</param>
+    /// <param name="to">The user phone number to send the template message to.</param>
+    /// <param name="template">The raw template object to serialize and send, including name, language and other properties.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages"/>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#components-object"/>
+    public static Task SendTemplateAsync(this IWhatsAppClient client, string from, string to, object template, CancellationToken cancellationToken = default)
         => client.SendAsync(from, new
         {
             messaging_product = "whatsapp",
             to = NormalizeNumber(to),
             type = "template",
-            template = new
-            {
-                name = templateName,
-                language = new
-                {
-                    code = code
-                }
-            }
-        });
+            template
+        }, cancellationToken);
 
     /// <summary>
     /// Replies to a user message.
@@ -98,6 +96,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="message">The message to reply to.</param>
     /// <param name="reply">The text message to respond with.</param>
     /// <returns>The identifier of the reply.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string reply)
         => client.SendAsync(service, new
         {
@@ -124,6 +123,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="reply">The text message to respond with.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <returns>The identifier of the reply message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string text, Button button)
         => client.SendAsync(service, new
         {
@@ -162,6 +162,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <returns>The identifier of the reply message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string reply, Button button1, Button button2)
         => client.SendAsync(service, new
         {
@@ -202,6 +203,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="button3">Interactive button for a user choice.</param>
     /// <returns>The identifier of the reply message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply, Button button1, Button button2, Button button3)
         => client.SendAsync(message.To.Id, new
         {
@@ -240,6 +242,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="reaction">The reaction from the user.</param>
     /// <param name="reply">The text message to respond with.</param>
     /// <returns>The identifier of the reply message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, ReactionMessage message, string reply)
         => client.SendAsync(message.To.Id, new
         {
@@ -265,6 +268,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="to">The originating user to send a message to.</param>
     /// <param name="message">The text message to send.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message)
         => SendAsync(client, to.To.Id, to.From.Number, message);
 
@@ -276,6 +280,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="message">The text message to send.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button)
         => SendAsync(client, to.To.Id, to.From.Number, message, button);
 
@@ -288,6 +293,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button1, Button button2)
         => SendAsync(client, to.To.Id, to.From.Number, message, button1, button2);
 
@@ -301,6 +307,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="button3">Interactive button for a user choice.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button1, Button button2, Button button3)
         => SendAsync(client, to.To.Id, to.From.Number, message, button1, button2, button3);
 
@@ -335,6 +342,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="message">The text message to send.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button)
         => client.SendAsync(from, new
         {
@@ -370,6 +378,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button1, Button button2)
         => client.SendAsync(from, new
         {
@@ -407,6 +416,7 @@ static partial class WhatsAppClientExtensions
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="button3">Interactive button for a user choice.</param>
     /// <returns>The identifier of the sent message.</returns>
+    /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button1, Button button2, Button button3)
         => client.SendAsync(from, new
         {


### PR DESCRIPTION
WhatsApp for Business doesn't have the concept of reengaging or anything like it. It's just templates, with or without complex parameters.

Since we don't offer a full typed model for template objects (for now?) we just let the user construct the object themselves and we just provide the simple template as a ctor overload on the TemplateResponse instead.

This is a balance between simplicy and a comprehensive API for template messages that is perhaps part of another feature.