### PR TITLE
Make usability extension methods public

### DIFF
--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Usability extensions for common messaging scenarios for WhatsApp.
 /// </summary>
-static partial class WhatsAppClientExtensions
+public static partial class WhatsAppClientExtensions
 {
     /// <summary>
     /// Creates an authenticated HTTP client for the given service number.


### PR DESCRIPTION
We should keep the public API to send messages directly through the IWhatsAppClient. This makes the app more reusable in scenarios that aren't implemented directly as functionality pipelines (i.e. async or scheduled jobs that notify users of updates).

The functionality pipeline approach works best for request/reponse scenarios where the user is driving a conversation, but it's not the only scenario we want to cover with this library.