### PR TITLE
Rename Text to Reply as a message extension

### DIFF
--- a/src/SampleApp/Sample/Program.cs
+++ b/src/SampleApp/Sample/Program.cs
@@ -78,12 +78,12 @@ static async IAsyncEnumerable<Response> ProcessMessagesAsync(
     else if (message is InteractiveMessage interactive)
     {
         logger.LogWarning("👤 chose {Button} ({Title})", interactive.Button.Id, interactive.Button.Title);
-        yield return interactive.Text($"👤 chose: {interactive.Button.Title} ({interactive.Button.Id})");
+        yield return interactive.Reply($"👤 chose: {interactive.Button.Title} ({interactive.Button.Id})");
     }
     else if (message is ReactionMessage reaction)
     {
         logger.LogInformation("👤 reaction: {Reaction}", reaction.Emoji);
-        yield return reaction.Text($"👤 reaction: {reaction.Emoji}");
+        yield return reaction.Reply($"👤 reaction: {reaction.Emoji}");
     }
     else if (message is StatusMessage status)
     {
@@ -95,7 +95,7 @@ static async IAsyncEnumerable<Response> ProcessMessagesAsync(
 
         // simulate some hard work at hand, like doing some LLM-stuff :)
         //await Task.Delay(2000);
-        yield return content.Text(
+        yield return content.Reply(
             $"☑️ Got your {content.Content.Type}:\r\n{JsonSerializer.Serialize(content, options)}",
             new Button("btn_good", "👍"),
             new Button("btn_bad", "👎"));

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -22,13 +22,13 @@ public static partial class MessageExtensions
     /// <summary>
     /// Creates a text response for the message.
     /// </summary>
-    public static TextResponse Text(this Message message, string text)
+    public static TextResponse Reply(this Message message, string text)
         => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, text);
 
     /// <summary>
     /// Creates a text response with buttons for the message.
     /// </summary>
-    public static TextResponse Text(this Message message, string text, Button button1, Button? button2 = default)
+    public static TextResponse Reply(this Message message, string text, Button button1, Button? button2 = default)
         => new(message.From.Number, message.To.Id, message.Id, message.ConversationId, text, button1, button2);
 
     /// <summary>

--- a/src/WhatsApp/TextResponse.cs
+++ b/src/WhatsApp/TextResponse.cs
@@ -7,7 +7,7 @@
 /// interaction. If no buttons are provided, the response will consist of  only the text message.</remarks>
 /// <param name="Number">The phone number of the recipient in international format.</param>
 /// <param name="Service">The identifier of the service handling the message.</param>
-/// <param name="Context">The unique identifier of the message to which the reaction is being sent.</param>
+/// <param name="Context">The unique identifier of the message to which this response is a reply to .</param>
 /// <param name="Text">The text content of the response message.</param>
 /// <param name="Button1">An optional button to include in the response for user interaction.</param>
 /// <param name="Button2">An optional second button to include in the response for user interaction.</param>


### PR DESCRIPTION
It's not very intuitive to have a React and a Text method. The former is a verb and the latter a noun, but in realiy, it's implemented as a Reply over the IWhatsAppClient, so why not call it that?