### PR TITLE
Improve feature filter naming to avoid potential collisions

### DIFF
--- a/src/WhatsApp/FeatureFilter.cs
+++ b/src/WhatsApp/FeatureFilter.cs
@@ -11,9 +11,11 @@ namespace Devlooped.WhatsApp;
 /// application's dependency injection container. It supports evaluating features such as <see
 /// cref="FeatureFlags.Storage"/> and <see cref="FeatureFlags.Conversation"/>.</remarks>
 /// <param name="serviceProvider"></param>
-[FilterAlias(nameof(FeatureFilter))]
+[FilterAlias(Alias)]
 public class FeatureFilter(IServiceProvider serviceProvider) : IFeatureFilter
 {
+    public const string Alias = "whatsapp_features";
+
     public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
     {
         var result = default(bool);
@@ -36,8 +38,8 @@ static class FeatureFilterExtensions
             .AddConfiguration(configuration)
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                    { $"FeatureManagement:{FeatureFlags.Storage.ToString()}:EnabledFor:0:Name", nameof(FeatureFilter) },
-                    { $"FeatureManagement:{FeatureFlags.Conversation.ToString()}:EnabledFor:0:Name", nameof(FeatureFilter) }
+                    { $"FeatureManagement:{FeatureFlags.Storage}:EnabledFor:0:Name", FeatureFilter.Alias },
+                    { $"FeatureManagement:{FeatureFlags.Conversation}:EnabledFor:0:Name", FeatureFilter.Alias }
             })
             .Build();
 

--- a/src/WhatsApp/FeatureFlags.cs
+++ b/src/WhatsApp/FeatureFlags.cs
@@ -7,7 +7,7 @@ namespace Devlooped.WhatsApp;
 /// </summary>
 /// <remarks>Feature flags are used to control the availability of specific features within the application. Use
 /// this enumeration to specify which features are being targeted for configuration or runtime checks.</remarks>
-public enum FeatureFlags
+enum FeatureFlags
 {
     Storage,
     Conversation


### PR DESCRIPTION
A filter simply named "FeatureFilter" as an alias might collide with consumers that also use filters for their own functionality.

So we make it more unique.

Also, since leveraging feature flags is something we use as an internal implementation detail, we make the FeatureFlags enum internal instead, since it's not intended for public consumption.