### PR TITLE
Add missing MessageType.Response

### DIFF
--- a/src/WhatsApp/IMessage.cs
+++ b/src/WhatsApp/IMessage.cs
@@ -52,4 +52,9 @@ public interface IMessage
     /// selection is a response to.
     /// </summary>
     string? Context { get; }
+
+    /// <summary>
+    /// Gets the type of the message.
+    /// </summary>
+    MessageType Type { get; }
 }

--- a/src/WhatsApp/MessageType.cs
+++ b/src/WhatsApp/MessageType.cs
@@ -1,7 +1,7 @@
 ﻿namespace Devlooped.WhatsApp;
 
 /// <summary>
-/// Type of message received by the service.
+/// Type of message.
 /// </summary>
 public enum MessageType
 {
@@ -25,6 +25,10 @@ public enum MessageType
     /// Message contains a status update.
     /// </summary>
     Status,
+    /// <summary>
+    /// Message is a response from the service, rather than an incoming message.
+    /// </summary>
+    Response,
     /// <summary>
     /// Message type is not supported by the WhatsApp for Business service.
     /// </summary>

--- a/src/WhatsApp/Response.cs
+++ b/src/WhatsApp/Response.cs
@@ -19,6 +19,9 @@ public abstract partial record Response(string UserNumber, string ServiceId, str
     /// <inheritdoc/>
     public long Timestamp { get; init; }
 
+    /// <inheritdoc/>
+    public MessageType Type => MessageType.Response;
+
     /// <summary>
     /// Sends a request asynchronously using the specified WhatsApp client.
     /// </summary>


### PR DESCRIPTION
Add the `MessageType Type` property to `IMessage` so we can easily tell apart the type of message like we had before when the pipeline was built on `Message` before we introduced the interface for responses.