### PR TITLE
Fix naming of parameters to match uniform usage in the API

### DIFF
--- a/src/WhatsApp/TextResponse.cs
+++ b/src/WhatsApp/TextResponse.cs
@@ -19,12 +19,12 @@ public record TextResponse(string Number, string Service, string Context, string
         if (Button1 != null)
         {
             return (Button2 == null ?
-                client.ReplyAsync(UserNumber, ServiceId, Context, Text, Button1) :
-                client.ReplyAsync(UserNumber, ServiceId, Context, Text, Button1, Button2));
+                client.ReplyAsync(ServiceId, UserNumber, Context, Text, Button1) :
+                client.ReplyAsync(ServiceId, UserNumber, Context, Text, Button1, Button2));
         }
         else
         {
-            return client.ReplyAsync(UserNumber, ServiceId, Context, Text);
+            return client.ReplyAsync(ServiceId, UserNumber, Context, Text);
         }
     }
 }

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -32,11 +32,11 @@ public static partial class WhatsAppClientExtensions
     /// webhook endpoint is invoked with a message.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the mark read through.</param>
+    /// <param name="serviceId">The service number to send the mark read through.</param>
     /// <param name="messageId">The message identifier to mark as read.</param>
     /// <param name="cancellation">The cancellation token.</param>
-    public static Task MarkReadAsync(this IWhatsAppClient client, string from, string messageId, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task MarkReadAsync(this IWhatsAppClient client, string serviceId, string messageId, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             status = "read",
@@ -58,18 +58,18 @@ public static partial class WhatsAppClientExtensions
     /// Reacts to a message.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the reaction through.</param>
-    /// <param name="to">The user phone number to send the reaction to.</param>
+    /// <param name="serviceId">The service number to send the reaction through.</param>
+    /// <param name="userNumber">The user phone number to send the reaction to.</param>
     /// <param name="messageId">The message identifier to react to.</param>
     /// <param name="emoji">The reaction emoji.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#reaction-object"/>
-    public static Task ReactAsync(this IWhatsAppClient client, string from, string to, string messageId, string emoji, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task ReactAsync(this IWhatsAppClient client, string serviceId, string userNumber, string messageId, string emoji, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             recipient_type = "individual",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "reaction",
             reaction = new
             {
@@ -82,18 +82,18 @@ public static partial class WhatsAppClientExtensions
     /// Sends a template message.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the template through.</param>
-    /// <param name="to">The user phone number to send the template message to.</param>
+    /// <param name="serviceId">The service number to send the template through.</param>
+    /// <param name="userNumber">The user phone number to send the template message to.</param>
     /// <param name="template">The raw template object to serialize and send, including name, language and other properties.</param>
     /// <param name="cancellation">Cancellation token for the async operation.</param>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages"/>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#components-object"/>
-    public static Task SendTemplateAsync(this IWhatsAppClient client, string from, string to, object template, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task SendTemplateAsync(this IWhatsAppClient client, string serviceId, string userNumber, object template, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "template",
             template
         }, cancellation);
@@ -102,18 +102,20 @@ public static partial class WhatsAppClientExtensions
     /// Replies to a user message.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="message">The message to reply to.</param>
+    /// <param name="serviceId">The service number to send through.</param>
+    /// <param name="userNumber">The user phone number to send to.</param>
     /// <param name="reply">The text message to respond with.</param>
+    /// <param name="replyTo">The message to reply to.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the reply.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
-    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string reply, CancellationToken cancellation = default)
-        => client.SendAsync(service, new
+    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string serviceId, string userNumber, string replyTo, string reply, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(number),
+            to = NormalizeNumber(userNumber),
             type = "text",
             context = new
             {
@@ -129,19 +131,21 @@ public static partial class WhatsAppClientExtensions
     /// Replies to a user message with an additional interactive button.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="message">The message to reply to.</param>
+    /// <param name="serviceId">The service number to send through.</param>
+    /// <param name="userNumber">The user phone number to send to.</param>
     /// <param name="reply">The text message to respond with.</param>
+    /// <param name="replyTo">The message to reply to.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string text, Button button, CancellationToken cancellation = default)
-        => client.SendAsync(service, new
+    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string serviceId, string userNumber, string replyTo, string text, Button button, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(number),
+            to = NormalizeNumber(userNumber),
             type = "interactive",
             context = new
             {
@@ -168,20 +172,22 @@ public static partial class WhatsAppClientExtensions
     /// Replies to a user message with a additional interactive buttons.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="message">The message to reply to.</param>
+    /// <param name="serviceId">The service number to send through.</param>
+    /// <param name="userNumber">The user phone number to send to.</param>
     /// <param name="reply">The text message to respond with.</param>
+    /// <param name="replyTo">The message to reply to.</param>
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string number, string service, string replyTo, string reply, Button button1, Button button2, CancellationToken cancellation = default)
-        => client.SendAsync(service, new
+    public static Task<string?> ReplyAsync(this IWhatsAppClient client, string serviceId, string userNumber, string replyTo, string reply, Button button1, Button button2, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(number),
+            to = NormalizeNumber(userNumber),
             type = "interactive",
             context = new
             {
@@ -279,46 +285,46 @@ public static partial class WhatsAppClientExtensions
     /// Sends a text message a user given his incoming message, without making it a reply.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="to">The originating user to send a message to.</param>
+    /// <param name="source">The originating source user message send to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, CancellationToken cancellation = default)
-        => SendAsync(client, to.Service.Id, to.User.Number, message, cancellation);
+    public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, CancellationToken cancellation = default)
+        => SendAsync(client, source.Service.Id, source.User.Number, message, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="to">The originating user to send a message to.</param>
+    /// <param name="source">The originating source user message send to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button, CancellationToken cancellation = default)
-        => SendAsync(client, to.Service.Id, to.User.Number, message, button, cancellation);
+    public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button, CancellationToken cancellation = default)
+        => SendAsync(client, source.Service.Id, source.User.Number, message, button, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="to">The originating user to send a message to.</param>
+    /// <param name="source">The originating source user message send to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button1, Button button2, CancellationToken cancellation = default)
-        => SendAsync(client, to.Service.Id, to.User.Number, message, button1, button2, cancellation);
+    public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button1, Button button2, CancellationToken cancellation = default)
+        => SendAsync(client, source.Service.Id, source.User.Number, message, button1, button2, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="to">The originating user to send a message to.</param>
+    /// <param name="source">The originating source user message send to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
@@ -326,25 +332,25 @@ public static partial class WhatsAppClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, Message to, string message, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
-        => SendAsync(client, to.Service.Id, to.User.Number, message, button1, button2, button3, cancellation);
+    public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
+        => SendAsync(client, source.Service.Id, source.User.Number, message, button1, button2, button3, cancellation);
 
     /// <summary>
     /// Sends a text message a user.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the message through.</param>
-    /// <param name="to">The user phone number to send the message to.</param>
+    /// <param name="serviceId">The service number to send the message through.</param>
+    /// <param name="userNumber">The user phone number to send the message to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task<string?> SendAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "text",
             text = new
             {
@@ -356,20 +362,20 @@ public static partial class WhatsAppClientExtensions
     /// Sends a text message a user.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the message through.</param>
-    /// <param name="to">The user phone number to send the message to.</param>
+    /// <param name="serviceId">The service number to send the message through.</param>
+    /// <param name="userNumber">The user phone number to send the message to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button">Interactive button for users to reply.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task<string?> SendAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, Button button, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "interactive",
             interactive = new
             {
@@ -392,21 +398,21 @@ public static partial class WhatsAppClientExtensions
     /// Sends a text message a user.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the message through.</param>
-    /// <param name="to">The user phone number to send the message to.</param>
+    /// <param name="serviceId">The service number to send the message through.</param>
+    /// <param name="userNumber">The user phone number to send the message to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button1, Button button2, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task<string?> SendAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, Button button1, Button button2, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "interactive",
             interactive = new
             {
@@ -430,8 +436,8 @@ public static partial class WhatsAppClientExtensions
     /// Sends a text message a user.
     /// </summary>
     /// <param name="client">The WhatsApp client.</param>
-    /// <param name="from">The service number to send the message through.</param>
-    /// <param name="to">The user phone number to send the message to.</param>
+    /// <param name="serviceId">The service number to send the message through.</param>
+    /// <param name="userNumber">The user phone number to send the message to.</param>
     /// <param name="message">The text message to send.</param>
     /// <param name="button1">Interactive button for a user choice.</param>
     /// <param name="button2">Interactive button for a user choice.</param>
@@ -439,13 +445,13 @@ public static partial class WhatsAppClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
-    public static Task<string?> SendAsync(this IWhatsAppClient client, string from, string to, string message, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
-        => client.SendAsync(from, new
+    public static Task<string?> SendAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
+        => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
             preview_url = false,
             recipient_type = "individual",
-            to = NormalizeNumber(to),
+            to = NormalizeNumber(userNumber),
             type = "interactive",
             interactive = new
             {


### PR DESCRIPTION
We refer to service number id as `serviceId` (which maps to `Message.Service.Id`) and user phone to `userNumber` (which maps to `User.Number`.

Use the same naming consistently.