### PR TITLE
Add missing Caption property to image and video content

### DIFF
--- a/src/WhatsApp/Content.cs
+++ b/src/WhatsApp/Content.cs
@@ -116,6 +116,11 @@ public record AudioContent(string Id, string Mime, string Sha256) : MediaContent
 /// <param name="Sha256">Hash of the image.</param>
 public record ImageContent(string Id, string Mime, string Sha256) : MediaContent(Id, Mime, Sha256)
 {
+    /// <summary>
+    /// Optional caption for the image.
+    /// </summary>
+    public string? Caption { get; init; }
+
     /// <inheritdoc/>
     [JsonIgnore]
     public override ContentType Type => ContentType.Image;
@@ -129,6 +134,11 @@ public record ImageContent(string Id, string Mime, string Sha256) : MediaContent
 /// <param name="Sha256">Hash of the video.</param>
 public record VideoContent(string Id, string Mime, string Sha256) : MediaContent(Id, Mime, Sha256)
 {
+    /// <summary>
+    /// Optional caption for the image.
+    /// </summary>
+    public string? Caption { get; init; }
+
     /// <inheritdoc/>
     [JsonIgnore]
     public override ContentType Type => ContentType.Video;

--- a/src/WhatsApp/Message.cs
+++ b/src/WhatsApp/Message.cs
@@ -136,6 +136,7 @@ public abstract partial record Message(string Id, Service Service, User User, lo
                     {
                       "$type": $msgType,
                       "id": $msg[$msgType].id,
+                      "caption": $msg[$msgType].caption,
                       "mime": $msg[$msgType].mime_type,
                       "sha256": $msg[$msgType].sha256
                     }


### PR DESCRIPTION
These two types of media elements can also contain a caption.

See https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#media-object