### PR TITLE
Allow pipeline handlers to send messages too

### DIFF
--- a/src/Tests/PipelineTests.cs
+++ b/src/Tests/PipelineTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 
@@ -205,6 +206,64 @@ public class PipelineTests(ITestOutputHelper output)
         Assert.IsAssignableFrom<ContentMessage>(messages[1][0]);
         Assert.IsAssignableFrom<Response>(messages[1][1]);
         Assert.IsAssignableFrom<ContentMessage>(messages[1][2]);
+    }
+
+    [Fact]
+    public async Task CanSendMessagesThroughPipeline()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>()
+            {
+                { "Meta:VerifyToken", "test-challenge" },
+                { "Meta:Numbers:1234", "test-access-token" }
+            })
+            .Build();
+
+        var handler = new Mock<IWhatsAppHandler>();
+        handler.Setup(x => x.HandleAsync(It.IsAny<IEnumerable<IMessage>>(), It.IsAny<CancellationToken>()))
+            .Returns((IEnumerable<IMessage> input, CancellationToken _) =>
+            {
+                // Timestamp in WhatsApp is in Unix seconds, so we need to simulate a delay
+                Thread.Sleep(1000);
+                var message = input.OfType<ContentMessage>().Last();
+                return AsyncEnum<Response>([message.Reply(message.Content.ToString() + " Reply")]);
+            });
+
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration);
+
+        var sent = 0;
+
+        // Override default IWhatsAppClient to prevent any actual sending
+        var client = new Mock<IWhatsAppClient>();
+        client.Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+              .Callback(() => sent++)
+              .ReturnsAsync(Ulid.NewUlid().ToString());
+
+        services.AddSingleton<IWhatsAppClient>(client.Object);
+
+        services.AddWhatsApp(handler.Object)
+            .Use(EchoAndHandle);
+
+        var pipeline = services.BuildServiceProvider().GetRequiredService<IWhatsAppHandler>();
+        await pipeline.HandleAsync(Text("Hello"));
+
+        // One from the echo, one from the actualy reply.
+        Assert.Equal(2, sent);
+
+        await pipeline.HandleAsync(Text("Again"));
+
+        Assert.Equal(4, sent);
+    }
+
+    static async IAsyncEnumerable<Response> EchoAndHandle(IEnumerable<IMessage> messages, IWhatsAppHandler inner, [EnumeratorCancellation] CancellationToken cancellation)
+    {
+        var content = messages.OfType<ContentMessage>().LastOrDefault();
+        if (content != null)
+            yield return content.Reply("Echo: " + content.Content.ToString());
+
+        await foreach (var response in inner.HandleAsync(messages, cancellation))
+            yield return response;
     }
 
     ContentMessage Text(string text) => new ContentMessage(

--- a/src/WhatsApp/SendResponsesHandler.cs
+++ b/src/WhatsApp/SendResponsesHandler.cs
@@ -19,7 +19,11 @@ class SendResponsesHandler : DelegatingWhatsAppHandler
     {
         await foreach (var response in InnerHandler.HandleAsync(messages, cancellation))
         {
-            yield return await response.SendAsync(client, cancellation);
+            // Only sent unsent messages.
+            if (string.IsNullOrEmpty(response.Id) && response.Timestamp == 0)
+                yield return await response.SendAsync(client, cancellation);
+            else
+                yield return response;
         }
     }
 }

--- a/src/WhatsApp/WhatsAppHandlerBuilder.cs
+++ b/src/WhatsApp/WhatsAppHandlerBuilder.cs
@@ -34,7 +34,12 @@ public class WhatsAppHandlerBuilder
         // If we can get the IWhatsApp at all, we wrap the target handler in the 
         // sender one, which will process responses and send them out to WhatsApp.
         if (services.GetService<IWhatsAppClient>() is { } client)
+        {
             handler = new SendResponsesHandler(handler, client);
+            // We also need to make sure we send messages added across the pipeline
+            // So we also place ourselves as the outermost handler.
+            (factories ??= []).Insert(0, (inner, _) => new SendResponsesHandler(inner, client));
+        }
 
         // Matches behavior of M.E.AI chat client builder
         // Apply the factories in reverse order, so that the first factory added is the outermost.

--- a/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
+++ b/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
@@ -221,7 +221,9 @@ public static class WhatsAppServiceCollectionExtensions
     static WhatsAppHandlerBuilder ConfigureServices(IServiceCollection services, WhatsAppHandlerBuilder builder, ServiceLifetime lifetime)
     {
         services.AddHttpClient("whatsapp").AddStandardResilienceHandler();
-        services.Add(new ServiceDescriptor(typeof(IWhatsAppClient), typeof(WhatsAppClient), lifetime));
+
+        if (services.FirstOrDefault(x => x.ServiceType == typeof(IWhatsAppClient)) == null)
+            services.Add(new ServiceDescriptor(typeof(IWhatsAppClient), typeof(WhatsAppClient), lifetime));
 
         if (services.FirstOrDefault(x => x.ServiceType == typeof(QueueServiceClient)) == null)
         {


### PR DESCRIPTION
The previous approach assumed responses would only be generated by the target handler, not the intermediate pipeline. This meant that reactions or other cross-cutting messages sent by other stages in the pipeline would be missed by the sender, since it wrapped only around the target handler in the pipeline.

We now wrap around the outermost handler too, and the sending handler (which will have two instances running now) only sends unsent messages it sees (since the innermost will have sent the ones generated by the target).

Obviously, this means that the placement of the UseConversation handler is relevant since it persists responses which have a message ID, which will only be the case for messages that reach it *after* the target and its innermost sender. Pipeline-generated messages that run before the conversation one will therefore not be saved (as expected) but will still be sent out by the outermost handler.