### PR TITLE
Add CLI options to avoid interactive prompts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,21 @@ in production, the CLI endpoint is not available. Example:
 
 ![](https://raw.githubusercontent.com/devlooped/WhatsApp/main/assets/img/cli.png)
 
-The console will automatically remember the last used WhatsApp endpoint, and uses YAML if possible 
+The console will automatically remember the last used WhatsApp endpoint, output format and simulated 
+user phone number.
+
+```bash
+Usage: whatsapp [OPTIONS]+
+Options:
+  -u, --url                  WhatsApp functions endpoint
+  -n, --number=VALUE         Your WhatsApp user phone number
+  -j, --json                 Format output as JSON
+  -t, --text                 Format output as text
+  -y, --yaml                 Format output as YAML
+  -?, -h, --help             Display this help.
+  -v, --version              Render tool version and updates.
+```
+
 to render the responses since it provides a more readable format than JSON.
 
 <!-- #cli -->

--- a/src/Console/Console.csproj
+++ b/src/Console/Console.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
     <PackageReference Include="ThisAssembly.Git" Version="2.0.14" PrivateAssets="all" />

--- a/src/Console/ConsoleOption.cs
+++ b/src/Console/ConsoleOption.cs
@@ -1,0 +1,21 @@
+﻿using Mono.Options;
+
+namespace Devlooped.WhatsApp;
+
+class ConsoleOption : OptionSet
+{
+    public ConsoleOption() =>
+        Add("u|url", "WhatsApp functions endpoint", u => Endpoint = u)
+       .Add("n|number=", "Your WhatsApp user phone number", n => Number = ParseNumber(n))
+       .Add("j|json", "Format output as JSON", _ => Format = OutputFormat.Json)
+       .Add("t|text", "Format output as text", _ => Format = OutputFormat.Text)
+       .Add("y|yaml", "Format output as YAML", _ => Format = OutputFormat.Yaml);
+
+    public string? Endpoint { get; private set; }
+
+    public OutputFormat? Format { get; private set; }
+
+    public int? Number { get; private set; }
+
+    static int ParseNumber(string value) => int.Parse([.. value.Where(char.IsDigit)]);
+}

--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -11,44 +11,43 @@ using Spectre.Console.Json;
 
 namespace Devlooped.WhatsApp;
 
-enum RenderMode
-{
-    Yaml,
-    Json,
-    Text,
-}
-
 [Service]
 class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) : IHostedService
 {
     readonly CancellationTokenSource cts = new();
 
-    string? serviceEndpoint = configuration["WhatsApp:Endpoint"];
+    string? service = configuration["WhatsApp:Endpoint"];
+    string? number = configuration["WhatsApp:Number"];
+    OutputFormat? format = Enum.TryParse<OutputFormat>(configuration["WhatsApp:Format"], true, out var value) ? value : null;
     string? clientEndpoint;
     HttpListener? listener;
-    RenderMode mode = RenderMode.Text;
     bool needsNewline = true;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrEmpty(serviceEndpoint))
+        if (string.IsNullOrEmpty(service))
         {
-            serviceEndpoint = AnsiConsole.Ask("Enter WhatsApp functions endpoint", "http://localhost:4242/whatsappcli");
+            service = AnsiConsole.Ask("Enter WhatsApp functions endpoint", "http://localhost:4242/whatsappcli");
             Config.Build(ConfigLevel.Global)
-                .SetString("WhatsApp", "Endpoint", serviceEndpoint);
+                .SetString("whatsapp", "endpoint", service);
         }
-        else if (!AnsiConsole.Confirm($"Use WhatsApp functions endpoint [link]{serviceEndpoint}[/]"))
+        if (format == null)
         {
-            serviceEndpoint = AnsiConsole.Ask("Enter WhatsApp functions endpoint", "http://localhost:4242/whatsappcli");
-            Config.Build(ConfigLevel.Global)
-                .SetString("WhatsApp", "Endpoint", serviceEndpoint);
-        }
+            var choices = Enum.GetValues<MessageType>();
+            format = AnsiConsole.Prompt(
+                new SelectionPrompt<OutputFormat>()
+                    .Title("Select output format")
+                    .AddChoices([OutputFormat.Text, OutputFormat.Yaml, OutputFormat.Json]));
 
-        var choices = Enum.GetValues<MessageType>();
-        mode = AnsiConsole.Prompt(
-            new SelectionPrompt<RenderMode>()
-                .Title("Select render mode")
-                .AddChoices([RenderMode.Text, RenderMode.Yaml, RenderMode.Json]));
+            Config.Build(ConfigLevel.Global)
+                .SetString("whatsapp", "format", format.ToString()!.ToLowerInvariant());
+        }
+        if (number == null)
+        {
+            number = AnsiConsole.Ask<long>("Enter WhatsApp user phone number", 987654321).ToString();
+            Config.Build(ConfigLevel.Global)
+                .SetString("whatsapp", "number", number);
+        }
 
         listener = new HttpListener();
         // Attempt to grab the first free port we can find on localhost
@@ -97,7 +96,7 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
                     var message = new ContentMessage(
                         Id: Ulid.NewUlid().ToString(),
                         Service: new Service(clientEndpoint!, "123456789"),
-                        User: new User("Console", "987654321"),
+                        User: new User("Console", number ?? "987654321"),
                         Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                         Content: new TextContent(input)
                     );
@@ -105,7 +104,7 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
                     using var httpClient = httpFactory.CreateClient("whatsapp");
                     var payload = JsonSerializer.Serialize(message, JsonContext.Default.Message);
 
-                    var response = await httpClient.PostAsync(serviceEndpoint, new StringContent(payload, Encoding.UTF8, "application/json"));
+                    var response = await httpClient.PostAsync(service, new StringContent(payload, Encoding.UTF8, "application/json"));
                     if (!response.IsSuccessStatusCode)
                     {
                         AnsiConsole.MarkupLine($"[red] Failed to send message.[/] [bold]Status Code:[/] {response.StatusCode}");
@@ -164,7 +163,7 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
             AnsiConsole.WriteLine();
 
         // Try to parse the request body as a dictionary and render it as YAML
-        if (mode == RenderMode.Yaml &&
+        if (format == OutputFormat.Yaml &&
             DictionaryConverter.Parse(json) is { } dictionary &&
             DictionaryConverter.ToYaml(dictionary) is { Length: > 0 } payload)
         {
@@ -175,7 +174,7 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
             return;
         }
 
-        if (mode == RenderMode.Text)
+        if (format == OutputFormat.Text)
         {
             try
             {

--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -16,9 +16,9 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
 {
     readonly CancellationTokenSource cts = new();
 
-    string? service = configuration["WhatsApp:Endpoint"];
-    string? number = configuration["WhatsApp:Number"];
-    OutputFormat? format = Enum.TryParse<OutputFormat>(configuration["WhatsApp:Format"], true, out var value) ? value : null;
+    string? service = configuration["whatsapp:endpoint"];
+    string? number = configuration["whatsapp:number"];
+    OutputFormat? format = Enum.TryParse<OutputFormat>(configuration["whatsApp:format"], true, out var value) ? value : null;
     string? clientEndpoint;
     HttpListener? listener;
     bool needsNewline = true;

--- a/src/Console/OutputFormat.cs
+++ b/src/Console/OutputFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace Devlooped.WhatsApp;
+
+enum OutputFormat
+{
+    Yaml,
+    Json,
+    Text,
+}

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -17,7 +17,6 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 var debug = false;
 var help = false;
 var version = false;
-var url = default(string);
 
 var options = new ConsoleOption
 {
@@ -39,11 +38,11 @@ if (help)
     return 0;
 }
 
-if (url != null || options.Number != null || options.Format != null)
+if (options.Endpoint != null || options.Number != null || options.Format != null)
 {
     var config = Config.Build(ConfigLevel.Global);
-    if (url != null)
-        config = config.SetString("whatsapp", "endpoint", url);
+    if (options.Endpoint != null)
+        config = config.SetString("whatsapp", "endpoint", options.Endpoint);
     if (options.Number != null)
         config = config.SetNumber("whatsapp", "number", (long)options.Number);
     if (options.Format != null)

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -1,37 +1,57 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Devlooped.WhatsApp;
+using DotNetConfig;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 // Some users reported not getting emoji on Windows, so we force UTF-8 encoding.
 // This not great, but I couldn't find a better way to do it.
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
     Console.InputEncoding = Console.OutputEncoding = Encoding.UTF8;
 
-// Alias -? to -h for help
-if (args.Contains("-?"))
-    args = [.. args.Select(x => x == "-?" ? "-h" : x)];
+var debug = false;
+var help = false;
+var version = false;
+var url = default(string);
 
-if (args.Contains("--debug"))
+var options = new ConsoleOption
 {
+    { "?|h|help", "Display this help.", h => help = h != null },
+    { "d|debug", "Debug the WhatsApp CLI.", d => debug = d != null, true },
+    { "v|version", "Render tool version and updates.", v => version = v != null },
+};
+
+options.Parse(args);
+
+if (debug)
     Debugger.Launch();
-    args = [.. args.Where(x => x != "--debug")];
+
+if (help)
+{
+    AnsiConsole.MarkupLine("Usage: [green]whatsapp[/] [grey][[OPTIONS]]+[/]");
+    AnsiConsole.WriteLine("Options:");
+    options.WriteOptionDescriptions(Console.Out);
+    return 0;
+}
+
+if (url != null || options.Number != null || options.Format != null)
+{
+    var config = Config.Build(ConfigLevel.Global);
+    if (url != null)
+        config = config.SetString("whatsapp", "endpoint", url);
+    if (options.Number != null)
+        config = config.SetNumber("whatsapp", "number", (long)options.Number);
+    if (options.Format != null)
+        config = config.SetString("whatsapp", "format", options.Format.ToString()!.ToLowerInvariant());
 }
 
 var host = Host.CreateApplicationBuilder(args);
 host.Logging.ClearProviders();
-
-host.Configuration.AddInMemoryCollection(new Dictionary<string, string?>()
-{
-    { "Logging:LogLevel:Default", "Information" },
-    { "Logging:LogLevel:Microsoft", "Warning" },
-    { "Logging:LogLevel:Microsoft.Hosting", "Warning" },
-    { "Logging:LogLevel:System.Net.Http", "Warning" },
-    { "Logging:LogLevel:Polly", "Warning" },
-});
 
 host.Configuration.AddDotNetConfig();
 host.Configuration.AddUserSecrets<Program>();
@@ -54,7 +74,7 @@ host.Services.AddServices();
 
 var app = host.Build();
 
-if (args.Contains("--version"))
+if (version)
 {
     app.ShowVersion();
     await app.ShowUpdatesAsync();

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Console": {
       "commandName": "Project",
-      "commandLineArgs": ""
+      "commandLineArgs": "-h"
     }
   }
 }


### PR DESCRIPTION
On launch, you can now provide the following:

```bash
Usage: whatsapp [OPTIONS]+
Options:
  -u, --url                  WhatsApp functions endpoint
  -n, --number=VALUE         Your WhatsApp user phone number
  -j, --json                 Format output as JSON
  -t, --text                 Format output as text
  -y, --yaml                 Format output as YAML
  -?, -h, --help             Display this help.
  -v, --version              Render tool version and updates.
```

Upon starting, if any of the options don't have values, user will get asked for them interactively. Upon choosing a value, it's persisted to the global `~\.netconfig` and never asked again. It can always be overriden (and auto-updated) via the option(s) again.