### PR TITLE
Allow message and content extensibility via AdditionalProperties

### DIFF
--- a/src/Tests/ConversationStorageTests.cs
+++ b/src/Tests/ConversationStorageTests.cs
@@ -1,0 +1,64 @@
+﻿namespace Devlooped.WhatsApp;
+
+public class ConversationStorageTests
+{
+    readonly static Service service = new("1234", "1234");
+    readonly static User user = new("kzu", "5678");
+
+    [Fact]
+    public async Task StoreAndLoadAdditionalProperties()
+    {
+        var storage = new ConversationStorage(CloudStorageAccount.DevelopmentStorageAccount);
+        var messageId = Ulid.NewUlid().ToString();
+        var conversationId = Ulid.NewUlid().ToString();
+
+        await storage.SaveAsync(new ContentMessage(
+            messageId,
+            service, user, DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            new TextContent("Hello")
+            {
+                AdditionalProperties = new()
+                {
+                    { "ContentProp", "ContentValue" },
+                    { "ContentNum", 42 },
+                    { "ContentBool", true },
+                }
+            })
+        {
+            ConversationId = conversationId,
+            AdditionalProperties = new()
+            {
+                { "MessageProp", "MessageValue" },
+                { "MessageNum", 42 },
+                { "MessageBool", true },
+            }
+        });
+
+        var message = await storage.GetMessageAsync(user.Number, messageId);
+
+        Assert.NotNull(message);
+        // Assert AdditionalProperties on message and content
+        var content = Assert.IsType<ContentMessage>(message);
+        Assert.NotNull(content.AdditionalProperties);
+        Assert.Equal("MessageValue", (string)content.AdditionalProperties["MessageProp"]!);
+        Assert.Equal(42, content.AdditionalProperties["MessageNum"]);
+        Assert.True((bool)content.AdditionalProperties["MessageBool"]!);
+
+        var text = Assert.IsType<TextContent>(content.Content);
+        Assert.NotNull(text.AdditionalProperties);
+        Assert.Equal("ContentValue", (string)text.AdditionalProperties["ContentProp"]!);
+        Assert.Equal(42, text.AdditionalProperties["ContentNum"]);
+        Assert.True((bool)text.AdditionalProperties["ContentBool"]!);
+
+        await foreach (var entry in storage.GetMessagesAsync(user.Number, conversationId))
+        {
+            content = Assert.IsType<ContentMessage>(message);
+            Assert.NotNull(content.AdditionalProperties);
+            Assert.Equal("MessageValue", (string)content.AdditionalProperties["MessageProp"]!);
+
+            text = Assert.IsType<TextContent>(content.Content);
+            Assert.NotNull(text.AdditionalProperties);
+            Assert.Equal("ContentValue", (string)text.AdditionalProperties["ContentProp"]!);
+        }
+    }
+}

--- a/src/WhatsApp/AdditionalPropertiesDictionary.cs
+++ b/src/WhatsApp/AdditionalPropertiesDictionary.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.Json.Serialization;
+
+namespace Devlooped.WhatsApp;
+
+/// <summary>Provides a dictionary used as the AdditionalProperties dictionary on Microsoft.Extensions.AI objects.</summary>
+[JsonConverter(typeof(AdditionalPropertiesDictionaryConverter))]
+public sealed class AdditionalPropertiesDictionary : AdditionalPropertiesDictionary<object?>
+{
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary"/> class.</summary>
+    public AdditionalPropertiesDictionary()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary"/> class.</summary>
+    public AdditionalPropertiesDictionary(IDictionary<string, object?> dictionary)
+        : base(dictionary)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary"/> class.</summary>
+    public AdditionalPropertiesDictionary(IEnumerable<KeyValuePair<string, object?>> collection)
+        : base(collection)
+    {
+    }
+
+    /// <summary>Creates a shallow clone of the properties dictionary.</summary>
+    /// <returns>
+    /// A shallow clone of the properties dictionary. The instance will not be the same as the current instance,
+    /// but it will contain all of the same key-value pairs.
+    /// </returns>
+    public new AdditionalPropertiesDictionary Clone() => new(this);
+}

--- a/src/WhatsApp/AdditionalPropertiesDictionaryConverter.cs
+++ b/src/WhatsApp/AdditionalPropertiesDictionaryConverter.cs
@@ -1,0 +1,151 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+
+namespace Devlooped.WhatsApp;
+
+class AdditionalPropertiesDictionaryConverter : JsonConverter<AdditionalPropertiesDictionary>
+{
+    const string TypeKey = "$type";
+    const string ValueKey = "$value";
+
+    public override AdditionalPropertiesDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object.");
+        }
+
+        var dictionary = new AdditionalPropertiesDictionary();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dictionary;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name.");
+            }
+
+            var key = reader.GetString()!;
+            reader.Read();
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var nestedObject = JsonSerializer.Deserialize<JsonElement>(ref reader, options);
+                if (nestedObject.TryGetProperty(TypeKey, out var typeElement) && typeElement.ValueKind == JsonValueKind.String)
+                {
+                    var typeString = typeElement.GetString()!;
+                    if (Enum.TryParse<TypeCode>(typeString, out var typeCode))
+                    {
+                        if (nestedObject.TryGetProperty(ValueKey, out var valueElement))
+                        {
+                            var value = DeserializePrimitive(typeCode, valueElement);
+                            dictionary[key] = value;
+                        }
+                        else
+                        {
+                            throw new JsonException($"Missing '{ValueKey}' in object with '{TypeKey}'.");
+                        }
+                    }
+                    else
+                    {
+                        dictionary[key] = nestedObject;
+                    }
+                }
+                else
+                {
+                    dictionary[key] = nestedObject;
+                }
+            }
+            else
+            {
+                var value = JsonSerializer.Deserialize<object>(ref reader, options);
+                dictionary[key] = value;
+            }
+        }
+
+        throw new JsonException("Unexpected end of JSON.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, AdditionalPropertiesDictionary value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (var kvp in value)
+        {
+            writer.WritePropertyName(kvp.Key);
+
+            if (kvp.Value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else if (IsPrimitiveType(kvp.Value.GetType()))
+            {
+                writer.WriteStartObject();
+                writer.WriteString(TypeKey, GetTypeCode(kvp.Value.GetType()).ToString());
+                writer.WritePropertyName(ValueKey);
+                JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+                writer.WriteEndObject();
+            }
+            else
+            {
+                JsonSerializer.Serialize(writer, kvp.Value, kvp.Value.GetType(), options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    static bool IsPrimitiveType(Type type) =>
+        type.IsPrimitive ||
+        type == typeof(string) ||
+        type == typeof(decimal) ||
+        type == typeof(DateTime) ||
+        type == typeof(Guid);
+
+    static TypeCode GetTypeCode(Type type) => type == typeof(Guid) ? TypeCode.Object : type switch
+    {
+        var t when t == typeof(bool) => TypeCode.Boolean,
+        var t when t == typeof(byte) => TypeCode.Byte,
+        var t when t == typeof(sbyte) => TypeCode.SByte,
+        var t when t == typeof(char) => TypeCode.Char,
+        var t when t == typeof(decimal) => TypeCode.Decimal,
+        var t when t == typeof(double) => TypeCode.Double,
+        var t when t == typeof(float) => TypeCode.Single,
+        var t when t == typeof(int) => TypeCode.Int32,
+        var t when t == typeof(uint) => TypeCode.UInt32,
+        var t when t == typeof(long) => TypeCode.Int64,
+        var t when t == typeof(ulong) => TypeCode.UInt64,
+        var t when t == typeof(short) => TypeCode.Int16,
+        var t when t == typeof(ushort) => TypeCode.UInt16,
+        var t when t == typeof(string) => TypeCode.String,
+        var t when t == typeof(DateTime) => TypeCode.DateTime,
+        _ => throw new NotSupportedException($"Type {type} is not supported.")
+    };
+
+    static object? DeserializePrimitive(TypeCode typeCode, JsonElement element) => typeCode switch
+    {
+        TypeCode.Boolean => element.GetBoolean(),
+        TypeCode.Byte => element.GetByte(),
+        TypeCode.SByte => element.GetSByte(),
+        TypeCode.Char => element.GetString()![0],
+        TypeCode.Decimal => element.GetDecimal(),
+        TypeCode.Double => element.GetDouble(),
+        TypeCode.Single => element.GetSingle(),
+        TypeCode.Int32 => element.GetInt32(),
+        TypeCode.UInt32 => element.GetUInt32(),
+        TypeCode.Int64 => element.GetInt64(),
+        TypeCode.UInt64 => element.GetUInt64(),
+        TypeCode.Int16 => element.GetInt16(),
+        TypeCode.UInt16 => element.GetUInt16(),
+        TypeCode.String => element.GetString(),
+        TypeCode.DateTime => element.GetDateTime(),
+        TypeCode.Object when element.ValueKind == JsonValueKind.String => Guid.Parse(element.GetString()!),
+        TypeCode.Object => throw new JsonException("Expected string for Guid."),
+        _ => throw new NotSupportedException($"TypeCode {typeCode} is not supported.")
+    };
+}

--- a/src/WhatsApp/AdditionalPropertiesDictionary{TValue}.cs
+++ b/src/WhatsApp/AdditionalPropertiesDictionary{TValue}.cs
@@ -1,0 +1,232 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Devlooped.WhatsApp;
+
+/// <summary>Provides a dictionary used as the AdditionalProperties dictionary on Microsoft.Extensions.AI objects.</summary>
+/// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(AdditionalPropertiesDictionary<>.DebugView))]
+public class AdditionalPropertiesDictionary<TValue> : IDictionary<string, TValue>, IReadOnlyDictionary<string, TValue>
+{
+    /// <summary>The underlying dictionary.</summary>
+    readonly Dictionary<string, TValue> dictionary;
+
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary{TValue}"/> class.</summary>
+    public AdditionalPropertiesDictionary()
+        => dictionary = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary{TValue}"/> class.</summary>
+    public AdditionalPropertiesDictionary(IDictionary<string, TValue> dictionary)
+        => this.dictionary = new(dictionary, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="AdditionalPropertiesDictionary{TValue}"/> class.</summary>
+    public AdditionalPropertiesDictionary(IEnumerable<KeyValuePair<string, TValue>> collection)
+        => dictionary = new(collection, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Creates a shallow clone of the properties dictionary.</summary>
+    /// <returns>
+    /// A shallow clone of the properties dictionary. The instance will not be the same as the current instance,
+    /// but it will contain all of the same key-value pairs.
+    /// </returns>
+    public AdditionalPropertiesDictionary<TValue> Clone() => new(dictionary);
+
+    /// <inheritdoc />
+    public TValue this[string key]
+    {
+        get => dictionary[key];
+        set => dictionary[key] = value;
+    }
+
+    /// <inheritdoc />
+    public ICollection<string> Keys => dictionary.Keys;
+
+    /// <inheritdoc />
+    public ICollection<TValue> Values => dictionary.Values;
+
+    /// <inheritdoc />
+    public int Count => dictionary.Count;
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, TValue>>.IsReadOnly => false;
+
+    /// <inheritdoc />
+    IEnumerable<string> IReadOnlyDictionary<string, TValue>.Keys => dictionary.Keys;
+
+    /// <inheritdoc />
+    IEnumerable<TValue> IReadOnlyDictionary<string, TValue>.Values => dictionary.Values;
+
+    /// <inheritdoc />
+    public void Add(string key, TValue value) => dictionary.Add(key, value);
+
+    /// <summary>Attempts to add the specified key and value to the dictionary.</summary>
+    /// <param name="key">The key of the element to add.</param>
+    /// <param name="value">The value of the element to add.</param>
+    /// <returns><see langword="true"/> if the key/value pair was added to the dictionary successfully; otherwise, <see langword="false"/>.</returns>
+    public bool TryAdd(string key, TValue value) => dictionary.TryAdd(key, value);
+
+    /// <inheritdoc />
+    void ICollection<KeyValuePair<string, TValue>>.Add(KeyValuePair<string, TValue> item) => ((ICollection<KeyValuePair<string, TValue>>)dictionary).Add(item);
+
+    /// <inheritdoc />
+    public void Clear() => dictionary.Clear();
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, TValue>>.Contains(KeyValuePair<string, TValue> item) =>
+        ((ICollection<KeyValuePair<string, TValue>>)dictionary).Contains(item);
+
+    /// <inheritdoc />
+    public bool ContainsKey(string key) => dictionary.ContainsKey(key);
+
+    /// <inheritdoc />
+    void ICollection<KeyValuePair<string, TValue>>.CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex) =>
+        ((ICollection<KeyValuePair<string, TValue>>)dictionary).CopyTo(array, arrayIndex);
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the <see cref="AdditionalPropertiesDictionary{TValue}"/>.
+    /// </summary>
+    /// <returns>An <see cref="AdditionalPropertiesDictionary{TValue}.Enumerator"/> that enumerates the contents of the <see cref="AdditionalPropertiesDictionary{TValue}"/>.</returns>
+    public Enumerator GetEnumerator() => new(dictionary.GetEnumerator());
+
+    /// <inheritdoc />
+    IEnumerator<KeyValuePair<string, TValue>> IEnumerable<KeyValuePair<string, TValue>>.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc />
+    public bool Remove(string key) => dictionary.Remove(key);
+
+    /// <inheritdoc />
+    bool ICollection<KeyValuePair<string, TValue>>.Remove(KeyValuePair<string, TValue> item) => ((ICollection<KeyValuePair<string, TValue>>)dictionary).Remove(item);
+
+    /// <summary>Attempts to extract a typed value from the dictionary.</summary>
+    /// <typeparam name="T">The type of the value to be retrieved.</typeparam>
+    /// <param name="key">The key to locate.</param>
+    /// <param name="value">
+    /// When this method returns, contains the value retrieved from the dictionary, if found and successfully converted to the requested type;
+    /// otherwise, the default value of <typeparamref name="T"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if a non-<see langword="null"/> value was found for <paramref name="key"/>
+    /// in the dictionary and converted to the requested type; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// If a non-<see langword="null"/> value is found for the key in the dictionary, but the value is not of the requested type and is
+    /// an <see cref="IConvertible"/> object, the method attempts to convert the object to the requested type.
+    /// </remarks>
+    public bool TryGetValue<T>(string key, [NotNullWhen(true)] out T? value)
+    {
+        if (TryGetValue(key, out TValue? obj))
+        {
+            switch (obj)
+            {
+                case T t:
+                    // The object is already of the requested type. Return it.
+                    value = t;
+                    return true;
+
+                case IConvertible:
+                    // The object is convertible; try to convert it to the requested type. Unfortunately, there's no
+                    // convenient way to do this that avoids exceptions and that doesn't involve a ton of boilerplate,
+                    // so we only try when the source object is at least an IConvertible, which is what ChangeType uses.
+                    try
+                    {
+                        value = (T)Convert.ChangeType(obj, typeof(T), CultureInfo.InvariantCulture);
+                        return true;
+                    }
+                    catch (Exception e) when (e is ArgumentException or FormatException or InvalidCastException or OverflowException)
+                    {
+                        // Ignore known failure modes.
+                    }
+
+                    break;
+            }
+        }
+
+        // Unable to find the value or convert it to the requested type.
+        value = default;
+        return false;
+    }
+
+    /// <summary>Gets the value associated with the specified key.</summary>
+    /// <returns><see langword="true"/> if the <see cref="AdditionalPropertiesDictionary{TValue}"/> contains an element with the specified key; otherwise <see langword="false"/>.</returns>
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out TValue value) => dictionary.TryGetValue(key, out value);
+
+    /// <inheritdoc />
+    bool IDictionary<string, TValue>.TryGetValue(string key, out TValue value) => dictionary.TryGetValue(key, out value!);
+
+    /// <inheritdoc />
+    bool IReadOnlyDictionary<string, TValue>.TryGetValue(string key, out TValue value) => dictionary.TryGetValue(key, out value!);
+
+    /// <summary>Copies all of the entries from <paramref name="items"/> into the dictionary, overwriting any existing items in the dictionary with the same key.</summary>
+    /// <param name="items">The items to add.</param>
+    internal void SetAll(IEnumerable<KeyValuePair<string, TValue>> items)
+    {
+        _ = Throw.IfNull(items);
+
+        foreach (var item in items)
+        {
+            dictionary[item.Key] = item.Value;
+        }
+    }
+
+    /// <summary>Enumerates the elements of an <see cref="AdditionalPropertiesDictionary{TValue}"/>.</summary>
+    public struct Enumerator : IEnumerator<KeyValuePair<string, TValue>>
+    {
+        /// <summary>The wrapped dictionary enumerator.</summary>
+        Dictionary<string, TValue>.Enumerator _dictionaryEnumerator;
+
+        /// <summary>Initializes a new instance of the <see cref="Enumerator"/> struct with the dictionary enumerator to wrap.</summary>
+        /// <param name="dictionaryEnumerator">The dictionary enumerator to wrap.</param>
+        internal Enumerator(Dictionary<string, TValue>.Enumerator dictionaryEnumerator)
+        {
+            _dictionaryEnumerator = dictionaryEnumerator;
+        }
+
+        /// <inheritdoc />
+        public KeyValuePair<string, TValue> Current => _dictionaryEnumerator.Current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public void Dispose() => _dictionaryEnumerator.Dispose();
+
+        /// <inheritdoc />
+        public bool MoveNext() => _dictionaryEnumerator.MoveNext();
+
+        /// <inheritdoc />
+        public void Reset() => Reset(ref _dictionaryEnumerator);
+
+        /// <summary>Calls <see cref="IEnumerator.Reset"/> on an enumerator.</summary>
+        static void Reset<TEnumerator>(ref TEnumerator enumerator)
+            where TEnumerator : struct, IEnumerator
+        {
+            enumerator.Reset();
+        }
+    }
+
+    /// <summary>Provides a debugger view for the collection.</summary>
+    sealed class DebugView(AdditionalPropertiesDictionary<TValue> properties)
+    {
+        readonly AdditionalPropertiesDictionary<TValue> _properties = Throw.IfNull(properties);
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public AdditionalProperty[] Items => (from p in _properties select new AdditionalProperty(p.Key, p.Value)).ToArray();
+
+        [DebuggerDisplay("{Value}", Name = "[{Key}]")]
+        public readonly struct AdditionalProperty(string key, TValue value)
+        {
+            [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+            public string Key { get; } = key;
+
+            [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+            public TValue Value { get; } = value;
+        }
+    }
+}

--- a/src/WhatsApp/Content.cs
+++ b/src/WhatsApp/Content.cs
@@ -17,6 +17,9 @@ namespace Devlooped.WhatsApp;
 [JsonDerivedType(typeof(UnknownContent), "unknown")]
 public abstract record Content
 {
+    /// <summary>Gets or sets any additional properties associated with the content.</summary>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+
     /// <summary>
     /// Get the type of content.
     /// </summary>

--- a/src/WhatsApp/ConversationStorage.cs
+++ b/src/WhatsApp/ConversationStorage.cs
@@ -4,6 +4,7 @@ namespace Devlooped.WhatsApp;
 
 class ConversationStorage : IConversationStorage
 {
+    static readonly DocumentSerializer defaultSerializer = new DocumentSerializer(JsonContext.DefaultOptions);
     readonly CloudStorageAccount storage;
     readonly Lazy<IDocumentRepository<IMessage>> messagesRepository;
     readonly Lazy<ITableStorage<Conversation>> conversationsRepository;
@@ -18,19 +19,21 @@ class ConversationStorage : IConversationStorage
     }
 
     protected virtual IDocumentRepository<IMessage> CreateMessagesRepository()
-        => DocumentRepository.Create<IMessage>(storage, "WhatsAppMessages", x => x.UserNumber, x => x.Id);
+        => DocumentRepository.Create<IMessage>(storage, "WhatsAppMessages", x => x.UserNumber, x => x.Id, defaultSerializer);
 
     protected virtual ITableStorage<Conversation> CreateConversationsRepository()
-        => BlobStorage.Create<Conversation>(storage, "whatsapp-conversations");
+        => BlobStorage.Create<Conversation>(storage, "whatsapp-conversations",
+            serializer: defaultSerializer);
 
     protected virtual IDocumentRepository<Conversation> CreateActiveConversationRepository()
         // We only have one active conversation by number. We can use the same table name since no conversation
         // will ever have the ID 'active'
-        => DocumentRepository.Create<Conversation>(storage, rowKey: _ => "active");
+        => DocumentRepository.Create<Conversation>(storage, rowKey: _ => "active", serializer: defaultSerializer);
 
     /// <inheritdoc/>
     public async Task SaveAsync(IMessage message, CancellationToken cancellationToken = default)
     {
+        var data = defaultSerializer.Serialize(message);
         if (!string.IsNullOrEmpty(message.ConversationId))
         {
             var conversation = await conversationsRepository.Value.GetAsync(message.UserNumber, message.ConversationId, cancellationToken) ??

--- a/src/WhatsApp/IMessage.cs
+++ b/src/WhatsApp/IMessage.cs
@@ -21,6 +21,9 @@ namespace Devlooped.WhatsApp;
 [JsonDerivedType(typeof(ReactionResponse), "response/reaction")]
 public interface IMessage
 {
+    /// <summary>Gets or sets any additional properties associated with the message.</summary>
+    AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+
     /// <summary>
     /// Gets the message id.
     /// </summary>

--- a/src/WhatsApp/JsonContext.cs
+++ b/src/WhatsApp/JsonContext.cs
@@ -37,6 +37,7 @@ namespace Devlooped.WhatsApp;
 [JsonSerializable(typeof(StatusMessage))]
 [JsonSerializable(typeof(UnsupportedMessage))]
 [JsonSerializable(typeof(MediaReference))]
+[JsonSerializable(typeof(Conversation))]
 public partial class JsonContext : JsonSerializerContext
 {
     static readonly Lazy<JsonSerializerOptions> options = new(() => CreateDefaultOptions());

--- a/src/WhatsApp/Message.cs
+++ b/src/WhatsApp/Message.cs
@@ -19,6 +19,9 @@ namespace Devlooped.WhatsApp;
 [JsonDerivedType(typeof(UnsupportedMessage), "unsupported")]
 public abstract partial record Message(string Id, Service Service, User User, long Timestamp) : IMessage
 {
+    /// <inheritdoc/>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+
     /// <summary>
     /// Optional related message identifier, such as message being replied 
     /// or reacted to, or a status message refers to, or the interactive 

--- a/src/WhatsApp/Response.cs
+++ b/src/WhatsApp/Response.cs
@@ -14,6 +14,9 @@
 public abstract partial record Response(string UserNumber, string ServiceId, string Context, string? ConversationId) : IMessage
 {
     /// <inheritdoc/>
+    public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
+
+    /// <inheritdoc/>
     public string Id { get; init; } = string.Empty;
 
     /// <inheritdoc/>


### PR DESCRIPTION
These properties dictionaries will be serialized propertly with the right primitive type and is properly persisted by default by the conversation storage. Both input messages as well as responses support this.