### PR TITLE
Massive timeout increase to aid local debugging

### DIFF
--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -109,13 +109,15 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
                     {
                         AnsiConsole.MarkupLine($"[red] Failed to send message.[/] [bold]Status Code:[/] {response.StatusCode}");
                     }
-
-                    AnsiConsole.Markup($":person_beard: ");
-                    needsNewline = true;
                 }
                 catch (Exception e)
                 {
                     AnsiConsole.WriteException(e);
+                }
+                finally
+                {
+                    AnsiConsole.Markup($":person_beard: ");
+                    needsNewline = true;
                 }
             }
         }
@@ -126,12 +128,11 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
         while (!cts.IsCancellationRequested)
         {
             var context = await listener!.GetContextAsync();
+            var request = context.Request;
+            var response = context.Response;
 
             try
             {
-                var request = context.Request;
-                var response = context.Response;
-
                 // Read the request body (if any)
                 var requestBody = "{}";
                 using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
@@ -140,19 +141,21 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
                 }
 
                 await RenderAsync(requestBody);
-
-                var buffer = Encoding.UTF8.GetBytes("OK");
-                response.ContentLength64 = buffer.Length;
-                response.ContentType = "text/plain";
-
-                await response.OutputStream.WriteAsync(buffer);
-                response.OutputStream.Close();
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error processing request: {ex.Message}");
                 context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
                 context.Response.Close();
+            }
+            finally
+            {
+                var buffer = Encoding.UTF8.GetBytes("OK");
+                response.ContentLength64 = buffer.Length;
+                response.ContentType = "text/plain";
+
+                await response.OutputStream.WriteAsync(buffer);
+                response.OutputStream.Close();
             }
         }
     }

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -56,14 +56,7 @@ host.Configuration.AddDotNetConfig();
 host.Configuration.AddUserSecrets<Program>();
 
 var http = host.Services.AddHttpClient("whatsapp");
-if (Debugger.IsAttached)
-{
-    http.ConfigureHttpClient(http => http.Timeout = TimeSpan.FromHours(1));
-}
-else
-{
-    http.AddStandardResilienceHandler();
-}
+http.ConfigureHttpClient(http => http.Timeout = TimeSpan.FromMinutes(30));
 
 var cts = new CancellationTokenSource();
 Console.CancelKeyPress += (s, e) => cts.Cancel();

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Console": {
       "commandName": "Project",
-      "commandLineArgs": "-h"
+      "commandLineArgs": ""
     }
   }
 }


### PR DESCRIPTION
Non-timeouts should be the default since this is a local development tool aid, and while debugging your local WhatsApp functionality pipelines, it can take quite a while for the response to come back. We don't want the client aborting the request to the server and causing an unexpected azure functions runtime error due to the client aborting the request before it's completed.