### PR TITLE
Allow server-side to send formatted responses to console

### DIFF
--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Spectre.Console;
 using Spectre.Console.Json;
+using Spectre.Console.Rendering;
 
 namespace Devlooped.WhatsApp;
 
@@ -62,8 +63,7 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
             }
             catch (HttpListenerException)
             {
-                // Port is already in use, try another one
-                listener.Prefixes.Clear();
+                listener = new HttpListener();
             }
         }
 
@@ -191,13 +191,14 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
                     if (message.Type == Client.MessageType.Reaction && text.Length == 0)
                         return;
 
+                    IRenderable body = message.Type == Client.MessageType.Reaction || (text.StartsWith("[") && text.EndsWith("]"))
+                        ? TryMarkup(text)
+                        : new Spectre.Console.Text(text).Overflow(Overflow.Fold);
+
                     var grid = new Grid()
                         .AddColumn(new GridColumn().Width(2))
                         .AddColumn(new GridColumn().Width(80))
-                        .AddRow(
-                            new Markup(":robot:"),
-                            new Spectre.Console.Text(text).Overflow(Overflow.Fold)
-                        );
+                        .AddRow(new Markup(":robot:"), body);
 
                     AnsiConsole.Write(grid);
 
@@ -221,5 +222,17 @@ class Interactive(IConfiguration configuration, IHttpClientFactory httpFactory) 
         {
             Width = Math.Min(100, AnsiConsole.Profile.Width)
         });
+    }
+
+    static IRenderable TryMarkup(string text)
+    {
+        try
+        {
+            return new Markup(text);
+        }
+        catch (Exception)
+        {
+            return new Spectre.Console.Text(text).Overflow(Overflow.Fold);
+        }
     }
 }


### PR DESCRIPTION
Since we now report when the WhatsApp pipeline is executed from the console, a handler might want to send formatted markup to the console.

Reactions (since they contain a single character by default) are safe to render as markup (and could contain arbitrary additional markup). For text, we attempt to parse markup if text starts with `[` and ends with `]` which is a pretty good indicator.

We fallback to text in that case.