### PR TITLE
Allow updating messages in storage

### DIFF
--- a/src/Tests/ConversationStorageTests.cs
+++ b/src/Tests/ConversationStorageTests.cs
@@ -60,5 +60,15 @@ public class ConversationStorageTests
             Assert.NotNull(text.AdditionalProperties);
             Assert.Equal("ContentValue", (string)text.AdditionalProperties["ContentProp"]!);
         }
+
+        message.AdditionalProperties?["Agent"] = "Calendar";
+
+        await storage.SaveAsync(message);
+
+        var updatedMessage = await storage.GetMessageAsync(user.Number, messageId);
+
+        Assert.NotNull(updatedMessage?.AdditionalProperties);
+        Assert.Equal("Calendar", updatedMessage.AdditionalProperties?["Agent"]);
+        Assert.Equal("MessageValue", (string)updatedMessage.AdditionalProperties!["MessageProp"]!);
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>Preview</LangVersion>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/WhatsApp/ConversationStorage.cs
+++ b/src/WhatsApp/ConversationStorage.cs
@@ -38,7 +38,16 @@ class ConversationStorage : IConversationStorage
             var conversation = await conversationsRepository.Value.GetAsync(message.UserNumber, message.ConversationId, cancellationToken) ??
                 new(message.UserNumber, message.ConversationId, [], message.Timestamp);
 
-            conversation.Messages.Add(message);
+            if (conversation.Messages.FirstOrDefault(x => x.Id == message.Id) is { } existing)
+            {
+                // Message is being updated, so we can just replace it
+                var index = conversation.Messages.IndexOf(existing);
+                conversation.Messages[index] = message;
+            }
+            else
+            {
+                conversation.Messages.Add(message);
+            }
 
             // Save the conversation
             await conversationsRepository.Value.PutAsync(conversation, cancellationToken);


### PR DESCRIPTION
Allow updating messages in storage

This is useful to update messages with additional properties set in the pipeline