### PR TITLE
Add a way to skip a handler in the pipeline

### DIFF
--- a/src/Tests/PipelineTests.cs
+++ b/src/Tests/PipelineTests.cs
@@ -31,6 +31,7 @@ public class PipelineTests(ITestOutputHelper output)
                 called = true;
                 return inner.HandleAsync(message, cancellation);
             })
+            .Use(handler => WhatsAppHandler.Skip)
             .Build();
 
         await pipeline.HandleAsync(new ReactionMessage("1234", service, user, 0, "🗽"));

--- a/src/WhatsApp/WhatsAppHandler.cs
+++ b/src/WhatsApp/WhatsAppHandler.cs
@@ -6,13 +6,28 @@
 public static class WhatsAppHandler
 {
     /// <summary>
-    /// An empty implementation of <see cref="IWhatsAppHandler"/> that does nothing.
+    /// An empty implementation of <see cref="IWhatsAppHandler"/> that does nothing and 
+    /// can be used to shortcircuit the processing of WhatsApp messages.
     /// </summary>
     public static IWhatsAppHandler Empty { get; } = new EmptyWhatsAppHandler();
+
+    /// <summary>
+    /// An empty implementation of <see cref="IWhatsAppHandler"/> that is skipped 
+    /// when building the processing pipeline. It's useful to implement conditional 
+    /// <c>Use(..)</c> logic that is dependent on runtime conditions, such as the 
+    /// hosting environment or configuration settings.
+    /// </summary>
+    public static IWhatsAppHandler Skip { get; } = new SKipWhatsAppHandler();
 
     class EmptyWhatsAppHandler : IWhatsAppHandler
     {
         public IAsyncEnumerable<Response> HandleAsync(IEnumerable<IMessage> messages, CancellationToken cancellation = default)
             => AsyncEnumerable.Empty<Response>();
+    }
+
+    class SKipWhatsAppHandler : IWhatsAppHandler
+    {
+        public IAsyncEnumerable<Response> HandleAsync(IEnumerable<IMessage> messages, CancellationToken cancellation = default)
+            => throw new NotSupportedException("This handler should never be invoked by the pipeline.");
     }
 }

--- a/src/WhatsApp/WhatsAppHandlerBuilder.cs
+++ b/src/WhatsApp/WhatsAppHandlerBuilder.cs
@@ -47,13 +47,17 @@ public class WhatsAppHandlerBuilder
         {
             for (var i = factories.Count - 1; i >= 0; i--)
             {
-                handler = factories[i](handler!, services);
-                if (handler is null)
+                var current = factories[i](handler!, services);
+                if (current is null)
                 {
                     Throw.InvalidOperationException(
                         $"The {nameof(WhatsAppHandlerBuilder)} entry at index {i} returned null. " +
                         $"Ensure that the callbacks passed to {nameof(Use)} return non-null {nameof(IWhatsAppHandler)} instances.");
                 }
+
+                // Only keep non-skipping handlers.
+                if (current != WhatsAppHandler.Skip)
+                    handler = factories[i](handler!, services);
             }
         }
 


### PR DESCRIPTION
When building the pipeline, sometimes it's useful for Use(...) to conditionally turn themselves off depending on some service or configuration. Rather than inject a passthrough DelegatingHandler needlessly, this allows these cases to return a WhatsAppHandler.Skip instead, which will not be added to the pipeline at all