### PR TITLE
Rename handlers Empty > Stop, Skip > Continue

### DIFF
--- a/src/Tests/PipelineTests.cs
+++ b/src/Tests/PipelineTests.cs
@@ -31,7 +31,7 @@ public class PipelineTests(ITestOutputHelper output)
                 called = true;
                 return inner.HandleAsync(message, cancellation);
             })
-            .Use(handler => WhatsAppHandler.Skip)
+            .Use(handler => WhatsAppHandler.Continue)
             .Build();
 
         await pipeline.HandleAsync(new ReactionMessage("1234", service, user, 0, "🗽"));

--- a/src/WhatsApp/ConsoleHandlerExtensions.cs
+++ b/src/WhatsApp/ConsoleHandlerExtensions.cs
@@ -28,7 +28,7 @@ public static class ConsoleHandlerExtensions
         {
             // In production environments, we have ZERO impact since we're not even added to the pipeline.
             if (services.GetRequiredService<IHostEnvironment>().IsProduction())
-                return WhatsAppHandler.Skip;
+                return WhatsAppHandler.Continue;
 
             return new ConsoleHandler(inner);
         });

--- a/src/WhatsApp/WhatsAppHandler.cs
+++ b/src/WhatsApp/WhatsAppHandler.cs
@@ -6,26 +6,28 @@
 public static class WhatsAppHandler
 {
     /// <summary>
-    /// An empty implementation of <see cref="IWhatsAppHandler"/> that does nothing and 
-    /// can be used to shortcircuit the processing of WhatsApp messages.
+    /// An empty implementation of <see cref="IWhatsAppHandler"/> that is skipped 
+    /// when building the processing pipeline so that normal processing continues 
+    /// as if this handler was never added at all. It's useful to implement conditional 
+    /// <c>Use(..)</c> logic that is dependent on runtime conditions, such as the 
+    /// hosting environment or configuration settings, with zero impact on runtime 
+    /// when the condition is not met.
     /// </summary>
-    public static IWhatsAppHandler Empty { get; } = new EmptyWhatsAppHandler();
+    public static IWhatsAppHandler Continue { get; } = new ContinueWhatsAppHandler();
 
     /// <summary>
-    /// An empty implementation of <see cref="IWhatsAppHandler"/> that is skipped 
-    /// when building the processing pipeline. It's useful to implement conditional 
-    /// <c>Use(..)</c> logic that is dependent on runtime conditions, such as the 
-    /// hosting environment or configuration settings.
+    /// An empty implementation of <see cref="IWhatsAppHandler"/> that stops further 
+    /// execution of the pipeline and generates no responses.
     /// </summary>
-    public static IWhatsAppHandler Skip { get; } = new SKipWhatsAppHandler();
+    public static IWhatsAppHandler Stop { get; } = new StopWhatsAppHandler();
 
-    class EmptyWhatsAppHandler : IWhatsAppHandler
+    class StopWhatsAppHandler : IWhatsAppHandler
     {
         public IAsyncEnumerable<Response> HandleAsync(IEnumerable<IMessage> messages, CancellationToken cancellation = default)
             => AsyncEnumerable.Empty<Response>();
     }
 
-    class SKipWhatsAppHandler : IWhatsAppHandler
+    class ContinueWhatsAppHandler : IWhatsAppHandler
     {
         public IAsyncEnumerable<Response> HandleAsync(IEnumerable<IMessage> messages, CancellationToken cancellation = default)
             => throw new NotSupportedException("This handler should never be invoked by the pipeline.");

--- a/src/WhatsApp/WhatsAppHandlerBuilder.cs
+++ b/src/WhatsApp/WhatsAppHandlerBuilder.cs
@@ -12,7 +12,7 @@ public class WhatsAppHandlerBuilder
     readonly Func<IServiceProvider, IWhatsAppHandler> handlerFactory;
     List<Func<IWhatsAppHandler, IServiceProvider, IWhatsAppHandler>>? factories;
 
-    public WhatsAppHandlerBuilder() : this(_ => WhatsAppHandler.Empty)
+    public WhatsAppHandlerBuilder() : this(_ => WhatsAppHandler.Stop)
     {
     }
 
@@ -56,7 +56,7 @@ public class WhatsAppHandlerBuilder
                 }
 
                 // Only keep non-skipping handlers.
-                if (current != WhatsAppHandler.Skip)
+                if (current != WhatsAppHandler.Continue)
                     handler = factories[i](handler!, services);
             }
         }


### PR DESCRIPTION
These names reflect much better what's the pipeline behavior when it encounters them:

* Stop: causes the pipeline to stop further processing and aborting any response generation.
* Continue: continues execution as if the handler wasn't even present in the pipeline (which it isn't :)).

Both allow runtime-conditional behaviors when used in combination with `Use(...)`.