### PR TITLE
Don't reset typing status indicator on reactions

### DIFF
--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -218,7 +218,8 @@ partial class Interactive(IConfiguration configuration, IHttpClientFactory httpF
                     if (message.Type == Client.MessageType.Reaction && text.Length == 0)
                         return;
 
-                    await ResetTypingAsync();
+                    if (message.Type != Client.MessageType.Reaction)
+                        await ResetTypingAsync();
 
                     IRenderable body = message.Type == Client.MessageType.Reaction || (text.StartsWith("[") && text.EndsWith("]"))
                         ? TryMarkup(text)


### PR DESCRIPTION
This matches more closely the WhatsApp client behavior.