### PR TITLE
Allow alternative text for console consumption and console-only messages

### DIFF
--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -17,6 +17,24 @@ public static partial class MessageExtensions
             get => (message.AdditionalProperties ??= []).TryGetValue("FromConsole", out var value) ? value as bool? ?? default : default;
             set => (message.AdditionalProperties ??= [])["FromConsole"] = value;
         }
+
+        /// <summary>
+        /// Alternative text to send to the console, if the message is intended to reach the CLI.
+        /// </summary>
+        public string? ConsoleText
+        {
+            get => (message.AdditionalProperties ??= []).TryGetValue("ConsoleText", out var value) ? value as string : null;
+            set => (message.AdditionalProperties ??= [])["ConsoleText"] = value;
+        }
+
+        /// <summary>
+        /// The message is intended for consumption only in the console and should not be sent to WhatsApp.
+        /// </summary>
+        public bool ConsoleOnly
+        {
+            get => (message.AdditionalProperties ??= []).TryGetValue("ConsoleOnly", out var value) ? value as bool? ?? default : default;
+            set => (message.AdditionalProperties ??= [])["ConsoleOnly"] = value;
+        }
     }
 
     /// <summary>

--- a/src/WhatsApp/ReactionResponse.cs
+++ b/src/WhatsApp/ReactionResponse.cs
@@ -21,9 +21,10 @@ public record ReactionResponse(string ServiceId, string UserNumber, string Conte
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellationToken = default)
     {
         if (service != null)
-            await client.ReactAsync(service.Secondary.Id, UserNumber, Context, Emoji, cancellationToken);
+            await client.ReactAsync(service.Secondary.Id, UserNumber, Context, this.ConsoleText ?? Emoji, cancellationToken);
 
-        await client.ReactAsync(ServiceId, UserNumber, Context, Emoji);
+        if (service == null || this.ConsoleOnly != true)
+            await client.ReactAsync(ServiceId, UserNumber, Context, Emoji);
 
         return Ulid.NewUlid().ToString();
     }

--- a/src/WhatsApp/TextResponse.cs
+++ b/src/WhatsApp/TextResponse.cs
@@ -22,24 +22,28 @@ public record TextResponse(string ServiceId, string UserNumber, string Context, 
     /// <inheritdoc/>
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)
     {
+        string? id = null;
         if (service != null)
-            await SendReplyAsync(client, service.Secondary.Id, cancellation);
+            id = await SendReplyAsync(client, service.Secondary.Id, this.ConsoleText ?? Text, cancellation);
 
-        return await SendReplyAsync(client, ServiceId, cancellation);
+        if (service == null || this.ConsoleOnly != true)
+            return await SendReplyAsync(client, ServiceId, Text, cancellation);
+
+        return id;
     }
 
-    Task<string?> SendReplyAsync(IWhatsAppClient client, string serviceId, CancellationToken cancellation)
+    Task<string?> SendReplyAsync(IWhatsAppClient client, string serviceId, string text, CancellationToken cancellation)
     {
         if (Button1 != null)
         {
             if (Button2 == null)
-                return client.ReplyAsync(serviceId, UserNumber, Context, Text, Button1, cancellation);
+                return client.ReplyAsync(serviceId, UserNumber, Context, text, Button1, cancellation);
             else
-                return client.ReplyAsync(serviceId, UserNumber, Context, Text, Button1, Button2, cancellation);
+                return client.ReplyAsync(serviceId, UserNumber, Context, text, Button1, Button2, cancellation);
         }
         else
         {
-            return client.ReplyAsync(serviceId, UserNumber, Context, Text, cancellation);
+            return client.ReplyAsync(serviceId, UserNumber, Context, text, cancellation);
         }
     }
 }


### PR DESCRIPTION
This makes it easier to have a richer dev-loop while avoiding polluting production messages, while avoiding #ifdefs everywhere.