### PR TITLE
Don't timeout on dev when replying to console

### DIFF
--- a/src/SampleApp/Sample/Program.cs
+++ b/src/SampleApp/Sample/Program.cs
@@ -71,6 +71,14 @@ if (builder.Configuration["EventGrid:Topic"] is { Length: > 0 } topic &&
         new Uri(topic), new Azure.AzureKeyCredential(key)));
 }
 
+if (builder.Environment.IsDevelopment())
+{
+    // Make sure we never timeout when calling back to the console
+    builder.Services.AddHttpClient()
+        .ConfigureHttpClientDefaults(client => client.ConfigureHttpClient(http =>
+          http.Timeout = TimeSpan.FromMinutes(30)));
+}
+
 var app = builder.Build();
 
 #region DebugInit


### PR DESCRIPTION
Sending messages to the console can take some time to complete since you might be debugging the console. Without an HTTP timeout increase, the function itself would timeout and cause in turn the console request to also fail, making debugging the end to end much harder.