### PR TITLE
Add extension methods for more intuitive config of messages

### DIFF
--- a/src/SampleApp/Sample/ProcessHandler.cs
+++ b/src/SampleApp/Sample/ProcessHandler.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Logging;
 
 class ProcessHandler(ILogger<Program> logger, JsonSerializerOptions options) : IWhatsAppHandler
 {
+    // Simulate agents responding
+    readonly string[] agents = ["tasks", "support", "sales"];
+
     public async IAsyncEnumerable<Response> HandleAsync(IEnumerable<IMessage> messages, [EnumeratorCancellation] CancellationToken cancellation = default)
     {
         // Avoid warning CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -55,15 +58,18 @@ class ProcessHandler(ILogger<Program> logger, JsonSerializerOptions options) : I
             // simulate some hard work at hand, like doing some LLM-stuff :)
             await Task.Delay(2000);
 
+            var agent = agents[Random.Shared.Next(agents.Length)];
+
             yield return content.Reply(
                 $"""
-                ☑️ Got your {content.Content.Type}
+                ☑️ {agent} got your {content.Content.Type}
                 ```
                 {JsonSerializer.Serialize(content, options)}
                 ```
                 """,
                 new Button("btn_good", "👍"),
-                new Button("btn_bad", "👎"));
+                new Button("btn_bad", "👎"))
+                .With(x => x["Agent"] = agent);
 
             yield return content.Reply("[grey][italic]This is for the CLI only.[/][/] [link=https://github.com/devlooped/WhatsApp]WhatsApp Lib[/]")
                 .ForConsoleOnly();

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
 
 namespace Devlooped.WhatsApp;
 
@@ -37,8 +38,47 @@ public static partial class MessageExtensions
         }
     }
 
+    extension<T>(T message) where T : IMessage
+    {
+        /// <summary>
+        /// Configures the response by applying the specified action to it.
+        /// </summary>
+        public T Configure(Action<T> configure)
+        {
+            configure(message);
+            return message;
+        }
+    }
+
+    extension(Message message)
+    {
+        /// <summary>
+        /// Configures the message by applying the specified action to it.
+        /// </summary>
+        public Message With(Action<AdditionalPropertiesDictionary> properties)
+        {
+            if (message.AdditionalProperties is null)
+                message = message with { AdditionalProperties = [] };
+
+            properties(message.AdditionalProperties);
+            return message;
+        }
+    }
+
     extension<T>(T response) where T : Response
     {
+        /// <summary>
+        /// Sets additional properties in the response.
+        /// </summary>
+        public T With(Action<AdditionalPropertiesDictionary> properties)
+        {
+            if (response.AdditionalProperties is null)
+                response = response with { AdditionalProperties = [] };
+
+            properties(response.AdditionalProperties);
+            return response;
+        }
+
         /// <summary>
         /// Marks the response for console use only by setting the <c>ConsoleOnly</c> property to <see langword="true"/>.
         /// </summary>


### PR DESCRIPTION
This allows to chain Configure (for entire message) or With (for properties).

In particular the additional properties is very useful since you typically have to initialize the object with the new dictionary before attempting to add values to it.