### PR TITLE
Further simplify message config and CLI extensions

### DIFF
--- a/src/WhatsApp/AzureFunctionsConsole.cs
+++ b/src/WhatsApp/AzureFunctionsConsole.cs
@@ -55,7 +55,7 @@ class AzureFunctionsConsole(
             if (message is UserMessage user)
                 await user.SendProgress(client, true, true).Ignore();
 
-            message.FromConsole = true;
+            message = message.With(x => x["FromConsole"] = true);
 
             // Await all responses
             // No action needed, just make sure all items are processed

--- a/src/WhatsApp/ConsoleHandlerExtensions.cs
+++ b/src/WhatsApp/ConsoleHandlerExtensions.cs
@@ -53,16 +53,15 @@ public static class ConsoleHandlerExtensions
                 if (message.FromConsole && user is not null)
                     console ??= user.Service;
 
-                // Mark non-console user messages as coming from the console by 
-                // composing the service id with the console service id for dual reply
+                // Composing the service id with the console service id for dual reply
                 if (console != null && !message.FromConsole && user is not null)
                 {
                     return user with
                     {
                         Service = new CompositeService(user.Service, console),
-                        FromConsole = true,
                     };
                 }
+
                 // Otherwise, just return the message as is.
                 return message;
             })];

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -13,29 +13,17 @@ public static partial class MessageExtensions
         /// <summary>
         /// Gets or sets whether the message was sent from the WhatsApp CLI.
         /// </summary>
-        public bool FromConsole
-        {
-            get => (message.AdditionalProperties ??= []).TryGetValue("FromConsole", out var value) ? value as bool? ?? default : default;
-            set => (message.AdditionalProperties ??= [])["FromConsole"] = value;
-        }
+        public bool FromConsole => message.AdditionalProperties?.TryGetValue("FromConsole", out var value) is true ? value as bool? ?? default : default;
 
         /// <summary>
         /// Alternative text to send to the console, if the message is intended to reach the CLI.
         /// </summary>
-        public string? ConsoleText
-        {
-            get => (message.AdditionalProperties ??= []).TryGetValue("ConsoleText", out var value) ? value as string : null;
-            set => (message.AdditionalProperties ??= [])["ConsoleText"] = value;
-        }
+        public string? ConsoleText => message.AdditionalProperties?.TryGetValue("ConsoleText", out var value) is true ? value as string : null;
 
         /// <summary>
         /// The message is intended for consumption only in the console and should not be sent to WhatsApp.
         /// </summary>
-        public bool ConsoleOnly
-        {
-            get => (message.AdditionalProperties ??= []).TryGetValue("ConsoleOnly", out var value) ? value as bool? ?? default : default;
-            set => (message.AdditionalProperties ??= [])["ConsoleOnly"] = value;
-        }
+        public bool ConsoleOnly => message.AdditionalProperties?.TryGetValue("ConsoleOnly", out var value) is true ? value as bool? ?? default : default;
     }
 
     extension<T>(T message) where T : IMessage
@@ -82,20 +70,12 @@ public static partial class MessageExtensions
         /// <summary>
         /// Marks the response for console use only by setting the <c>ConsoleOnly</c> property to <see langword="true"/>.
         /// </summary>
-        public T ForConsoleOnly()
-        {
-            response.ConsoleOnly = true;
-            return response;
-        }
+        public T ForConsoleOnly() => response.With(x => x["ConsoleOnly"] = true);
 
         /// <summary>
         /// Sets the console alternate text for the response, in case the response is intended to be sent to the CLI.
         /// </summary>
-        public T WithConsoleText(string text)
-        {
-            response.ConsoleText = text;
-            return response;
-        }
+        public T WithConsoleText(string text) => response.With(x => x["ConsoleText"] = text);
     }
 
     /// <summary>


### PR DESCRIPTION
Since our messages are records, we need to be careful with mutation. By moving the setting of the (internal-only) properties to drive console behavior, we avoid exposing public setters altogether.