### PR TITLE
Ensure we never send react/resply to WhatsApp for ConsoleOnly

### DIFF
--- a/src/WhatsApp/ReactionResponse.cs
+++ b/src/WhatsApp/ReactionResponse.cs
@@ -26,12 +26,15 @@ public record ReactionResponse(string ServiceId, string UserNumber, string Conte
             await client.ReactAsync(service.Secondary.Id, UserNumber, Context, this.ConsoleText ?? Emoji, cancellationToken);
 
         // If service is null, it's either a WhatsApp regular without CLI, or it's pure CLI.
-        // In both cases, we need to send the reaction to the WhatsApp service. 
-        // The other case is if we did get a composite service, but the message is not intended for console only.
-        if (service == null || this.ConsoleOnly != true)
-            await client.ReactAsync(ServiceId, UserNumber, Context,
-                // Automatically pick the CLI version of the text if sending to the CLI
-                ServiceId.IsCLI() ? this.ConsoleText ?? Emoji : Emoji);
+        // In the former case, we don't want to send messages that are CLI-only if the service id 
+        // is not actually a CLI service.
+        if (service == null && this.ConsoleOnly == true && !ServiceId.IsCLI())
+            return null;
+
+        // It may not be CLI-only but still provide a CLI-enhanced text.
+        await client.ReactAsync(ServiceId, UserNumber, Context,
+            // Automatically pick the CLI version of the text if sending to the CLI
+            ServiceId.IsCLI() ? this.ConsoleText ?? Emoji : Emoji);
 
         return Ulid.NewUlid().ToString();
     }

--- a/src/WhatsApp/TextResponse.cs
+++ b/src/WhatsApp/TextResponse.cs
@@ -24,19 +24,19 @@ public record TextResponse(string ServiceId, string UserNumber, string Context, 
     /// <inheritdoc/>
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)
     {
-        string? id = null;
         if (service != null)
-            id = await SendReplyAsync(client, service.Secondary.Id, this.ConsoleText ?? Text, cancellation);
+            await SendReplyAsync(client, service.Secondary.Id, this.ConsoleText ?? Text, cancellation);
 
         // If service is null, it's either a WhatsApp regular without CLI, or it's pure CLI.
-        // In both cases, we need to send the reaction to the WhatsApp service. 
-        // The other case is if we did get a composite service, but the message is not intended for console only.
-        if (service == null || this.ConsoleOnly != true)
-            return await SendReplyAsync(client, ServiceId,
-                // Automatically pick the CLI version of the text if sending to the CLI
-                ServiceId.IsCLI() ? this.ConsoleText ?? Text : Text, cancellation);
+        // In the former case, we don't want to send messages that are CLI-only if the service id 
+        // is not actually a CLI service.
+        if (service == null && this.ConsoleOnly == true && !ServiceId.IsCLI())
+            return null;
 
-        return id;
+        // It may not be CLI-only but still provide a CLI-enhanced text.
+        return await SendReplyAsync(client, ServiceId,
+            // Automatically pick the CLI version of the text if sending to the CLI
+            ServiceId.IsCLI() ? this.ConsoleText ?? Text : Text, cancellation);
     }
 
     Task<string?> SendReplyAsync(IWhatsAppClient client, string serviceId, string text, CancellationToken cancellation)


### PR DESCRIPTION
We had a bug where we'd still send ConsoleOnly messages where the ServiceId wasn't a CLI endpoint.