### PR TITLE
Minor CallToAction cleanup

### DIFF
--- a/src/WhatsApp/CallToActionResponse.cs
+++ b/src/WhatsApp/CallToActionResponse.cs
@@ -4,19 +4,25 @@
 /// Represents an interactive call to action that can be sent in response to a user message.
 /// </summary>
 /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages/"/>
-public record CallToActionResponse(string ServiceId, string UserNumber, string? Context, string Text, string ButtonText, string Url, string? ConversationId) : Response(ServiceId, UserNumber, Context, ConversationId)
+/// <param name="ServiceId">The identifier of the service handling the message.</param>
+/// <param name="UserNumber">The phone number of the recipient in international format.</param>
+/// <param name="Text">The content of the message calling to action.</param>
+/// <param name="Action">The action button text.</param>
+/// <param name="Url">The URL to navigate to when the action button is clicked.</param>
+/// /// <param name="ConversationId">The conversation id where this response was generated</param>
+public record CallToActionResponse(string ServiceId, string UserNumber, string Text, string Action, string Url, string? ConversationId) : Response(ServiceId, UserNumber, null, ConversationId)
 {
     readonly CompositeService? service;
 
-    internal CallToActionResponse(Service service, string userNumber, string? context, string Text, string ButtonText, string Url, string? conversationId)
-        : this(service.Id, userNumber, context, Text, ButtonText, Url, conversationId)
+    internal CallToActionResponse(Service service, string userNumber, string Text, string Action, string Url, string? conversationId)
+        : this(service.Id, userNumber, Text, Action, Url, conversationId)
         => this.service = service as CompositeService;
 
     protected override Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)
     {
         if (service != null)
-            return client.SendCallToActionAsync(service.Secondary.Id, UserNumber, Text, ButtonText, Url, cancellation);
+            return client.CallToActionAsync(service.Secondary.Id, UserNumber, Text, Action, Url, cancellation);
 
-        return client.SendCallToActionAsync(ServiceId, UserNumber, Text, ButtonText, Url, cancellation);
+        return client.CallToActionAsync(ServiceId, UserNumber, Text, Action, Url, cancellation);
     }
 }

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -112,10 +112,14 @@ public static partial class MessageExtensions
     /// <summary>
     /// Sends an interactive call to action response to the user message.
     /// </summary>
+    /// <param name="message">The originating user message.</param>
+    /// <param name="text">The content of the message calling to action.</param>
+    /// <param name="action">The action button text.</param>
+    /// <param name="url">The URL to navigate to when the action button is clicked.</param>
     public static CallToActionResponse CallToAction(this IMessage message, string text, string action, string url)
         => message is UserMessage user
-        ? new(user.Service, message.UserNumber, message.Id, text, action, url, message.ConversationId)
-        : new(message.ServiceId, message.UserNumber, message.Id, text, action, url, message.ConversationId);
+        ? new(user.Service, message.UserNumber, text, action, url, message.ConversationId)
+        : new(message.ServiceId, message.UserNumber, text, action, url, message.ConversationId);
 
     /// <summary>
     /// Creates a text reply for the message.

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -554,10 +554,10 @@ public static partial class WhatsAppClientExtensions
     /// <param name="serviceId">The identifier for the service sending the message.</param>
     /// <param name="userNumber">The phone number of the recipient. Must be in a valid format.</param>
     /// <param name="message">The text message to be sent to the user.</param>
-    /// <param name="buttonText">The text displayed on the call-to-action button.</param>
+    /// <param name="action">The text displayed on the call-to-action button.</param>
     /// <param name="cancellation">A token to monitor for cancellation requests. Defaults to <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static Task<string?> SendCallToActionAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, string buttonText, string url, CancellationToken cancellation = default)
+    public static Task<string?> CallToActionAsync(this IWhatsAppClient client, string serviceId, string userNumber, string message, string action, string url, CancellationToken cancellation = default)
         => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
@@ -576,7 +576,7 @@ public static partial class WhatsAppClientExtensions
                     name = "cta_url",
                     parameters = new
                     {
-                        display_text = buttonText,
+                        display_text = action,
                         url = url
                     }
                 }


### PR DESCRIPTION
- SendXXX is used when there isn't a clear verb we can use. In this case, CallToAction is already a verb/action so we don't need the Send prefix (just like Reply/React).
- Calls to action can (for now?) never be a reply to anything, they are standalone messages. Remove the Context everywhere therefore, since we don't use it at all anyway in the actual sending implementation.
- Unify naming on Action for the button text.