### PR TITLE
Model ConversationId as an extension property instead

### DIFF
--- a/src/Tests/PipelineTests.cs
+++ b/src/Tests/PipelineTests.cs
@@ -90,7 +90,10 @@ public class PipelineTests(ITestOutputHelper output)
 
         IAsyncEnumerable<Response> messages = new Response[]
         {
-            new TextResponse("123", "456", "Foo", "Bar", "Baz")
+            new TextResponse("123", "456", "Foo", "Bar")
+            {
+                ConversationId = "Baz"
+            }
         }.ToAsyncEnumerable();
 
         var order = new List<string>();
@@ -162,7 +165,10 @@ public class PipelineTests(ITestOutputHelper output)
             .Build();
 
         var storage = new MemoryConversationStorage();
-        var response = AsyncEnum<Response>([new TextResponse(service.Id, user.Number, "1234", null, "Bye")]);
+        var response = AsyncEnum<Response>([new TextResponse(service.Id, user.Number, "1234", null)
+        {
+            ConversationId = "Bye"
+        }]);
         var messages = new List<IMessage[]>();
 
         var handler = new Mock<IWhatsAppHandler>();

--- a/src/Tests/WhatsAppClientTests.cs
+++ b/src/Tests/WhatsAppClientTests.cs
@@ -147,7 +147,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         await stream.CopyToAsync(fs);
     }
 
-    [SecretsFact("Meta:VerifyToken", "MediaTo")]
+    [SecretsFact("Meta:VerifyToken", "MediaTo", Skip = "Media are transient and therefore this test requires an active message present")]
     public async Task ResolveMediaThrowsForNonExistentId()
     {
         var (configuration, client) = Initialize();

--- a/src/WhatsApp/CallToActionResponse.cs
+++ b/src/WhatsApp/CallToActionResponse.cs
@@ -9,13 +9,12 @@
 /// <param name="Text">The content of the message calling to action.</param>
 /// <param name="Action">The action button text.</param>
 /// <param name="Url">The URL to navigate to when the action button is clicked.</param>
-/// /// <param name="ConversationId">The conversation id where this response was generated</param>
-public record CallToActionResponse(string ServiceId, string UserNumber, string Text, string Action, string Url, string? ConversationId) : Response(ServiceId, UserNumber, null, ConversationId)
+public record CallToActionResponse(string ServiceId, string UserNumber, string Text, string Action, string Url) : Response(ServiceId, UserNumber, null)
 {
     readonly CompositeService? service;
 
-    internal CallToActionResponse(Service service, string userNumber, string Text, string Action, string Url, string? conversationId)
-        : this(service.Id, userNumber, Text, Action, Url, conversationId)
+    internal CallToActionResponse(Service service, string userNumber, string Text, string Action, string Url)
+        : this(service.Id, userNumber, Text, Action, Url)
         => this.service = service as CompositeService;
 
     protected override Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)

--- a/src/WhatsApp/ConversationHandler.cs
+++ b/src/WhatsApp/ConversationHandler.cs
@@ -17,9 +17,13 @@ class ConversationHandler(IWhatsAppHandler inner, IConversationStorage storage, 
         if (options.ReactOnConversation != null && messages.LastOrDefault() is ContentMessage content)
             yield return content.React(options.ReactOnConversation);
 
+        string? conversationId = null;
+
         foreach (var message in messages)
         {
             var fixup = await SetConversationIdAsync(message, cancellation);
+            conversationId = fixup.ConversationId;
+
             // Now that it's fixed, we can persist the message.
             await storage.SaveAsync(fixup, cancellation);
 
@@ -32,6 +36,8 @@ class ConversationHandler(IWhatsAppHandler inner, IConversationStorage storage, 
 
         await foreach (var response in base.HandleAsync(conversation, cancellation))
         {
+            response.ConversationId = conversationId;
+
             // We don't care about typing status or reaction messages for conversation storage
             if (response is not TypingResponse or ReactionResponse)
                 await storage.SaveAsync(response, cancellation);
@@ -53,10 +59,11 @@ class ConversationHandler(IWhatsAppHandler inner, IConversationStorage storage, 
     {
         var shouldReturnInputMessage = true;
 
-        if (!string.IsNullOrEmpty(message.ConversationId))
+        var conversationId = message.ConversationId;
+        if (!string.IsNullOrEmpty(conversationId))
         {
             var conversation = await storage
-                    .GetMessagesAsync(message.UserNumber, message.ConversationId, cancellationToken)
+                    .GetMessagesAsync(message.UserNumber, conversationId, cancellationToken)
                     // We need to sort in-memory since table-storage does not support ordering by timestamp 
                     // unless we're using CosmosDB, which we can't assume. 
                     // Note that conversations in WhatsApp are nevertheless short-lived, so this is acceptable.
@@ -79,8 +86,8 @@ class ConversationHandler(IWhatsAppHandler inner, IConversationStorage storage, 
 
     async Task<string> GetOrCreateConversationIdAsync(IMessage message, CancellationToken cancellationToken = default)
     {
-        if (!string.IsNullOrEmpty(message.ConversationId))
-            return message.ConversationId;
+        if (message.ConversationId is { Length: > 0 } conversationId)
+            return conversationId;
 
         // If the user is explicitly replying to a given message
         // We should try to use that conversion first
@@ -96,7 +103,7 @@ class ConversationHandler(IWhatsAppHandler inner, IConversationStorage storage, 
 
         // Use the conversation id for a message processed in the last ConversationWindowInSeconds seconds
         var conversation = await storage.GetActiveConversationAsync(message.UserNumber, cancellationToken);
-        var conversationId = conversation?.Id;
+        conversationId = conversation?.Id;
 
         if (conversationId == null || conversation?.Timestamp < timestamp)
         {

--- a/src/WhatsApp/ConversationStorage.cs
+++ b/src/WhatsApp/ConversationStorage.cs
@@ -33,10 +33,11 @@ class ConversationStorage : IConversationStorage
     /// <inheritdoc/>
     public async Task SaveAsync(IMessage message, CancellationToken cancellationToken = default)
     {
-        if (!string.IsNullOrEmpty(message.ConversationId))
+        var conversationId = message.ConversationId;
+        if (!string.IsNullOrEmpty(conversationId))
         {
-            var conversation = await conversationsRepository.Value.GetAsync(message.UserNumber, message.ConversationId, cancellationToken) ??
-                new(message.UserNumber, message.ConversationId, [], message.Timestamp);
+            var conversation = await conversationsRepository.Value.GetAsync(message.UserNumber, conversationId, cancellationToken) ??
+                new(message.UserNumber, conversationId, [], message.Timestamp);
 
             if (conversation.Messages.FirstOrDefault(x => x.Id == message.Id) is { } existing)
             {

--- a/src/WhatsApp/IMessage.cs
+++ b/src/WhatsApp/IMessage.cs
@@ -49,11 +49,6 @@ public interface IMessage
     long Timestamp { get; }
 
     /// <summary>
-    /// Gets the unique identifier for the current conversation where this message was included
-    /// </summary>
-    string? ConversationId { get; }
-
-    /// <summary>
     /// Optional related message identifier, such as message being replied 
     /// or reacted to, or a status message refers to, or the interactive 
     /// selection is a response to.

--- a/src/WhatsApp/Message.cs
+++ b/src/WhatsApp/Message.cs
@@ -39,9 +39,6 @@ public abstract partial record Message(string Id, Service Service, User User, lo
     [JsonPropertyName("notification")]
     internal string? NotificationId { get; init; }
 
-    /// <inheritdoc/>
-    public string? ConversationId { get; init; }
-
     const string JQ =
         """
         (

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -11,6 +11,33 @@ public static partial class MessageExtensions
     extension(IMessage message)
     {
         /// <summary>
+        /// Gets or sets an optional conversation identifier, used in combination with 
+        /// the <see cref="ConversationHandlerExtensions.UseConversation"/> and 
+        /// accompanying <see cref="IConversationStorage"/> suppport. 
+        /// </summary>
+        public string? ConversationId
+        {
+            get => (message.AdditionalProperties ??= []).TryGetValue("ConversationId", out var value) ? value as string : null;
+            set
+            {
+                if (value is not null)
+                {
+                    message.AdditionalProperties ??= [];
+                    message.AdditionalProperties["ConversationId"] = value;
+                }
+                else
+                {
+                    if (message.AdditionalProperties is not null)
+                    {
+                        message.AdditionalProperties.Remove("ConversationId");
+                        if (message.AdditionalProperties.Count == 0)
+                            message.AdditionalProperties = null;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether the message was sent from the WhatsApp CLI.
         /// </summary>
         public bool FromConsole => message.AdditionalProperties?.TryGetValue("FromConsole", out var value) is true ? value as bool? ?? default : default;
@@ -30,14 +57,14 @@ public static partial class MessageExtensions
         /// </summary>
         public ReactionResponse React(string emoji)
             => message is UserMessage user
-                ? new(user.Service, message.UserNumber, message.Id, message.ConversationId, emoji)
-                : new(message.ServiceId, message.UserNumber, message.Id, message.ConversationId, emoji);
+                ? new(user.Service, message.UserNumber, message.Id, emoji)
+                : new(message.ServiceId, message.UserNumber, message.Id, emoji);
 
         /// <summary>
         /// Creates a simple template response for the message.
         /// </summary>
         public TemplateResponse Template(string name, string language)
-            => new(message.ServiceId, message.UserNumber, message.Id, message.ConversationId, name, language);
+            => new(message.ServiceId, message.UserNumber, message.Id, name, language);
 
         /// <summary>
         /// Creates a complex template response for the message.
@@ -47,7 +74,7 @@ public static partial class MessageExtensions
         /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
         /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#components-object"/>
         public TemplateResponse Template(object template)
-            => new(message.ServiceId, message.UserNumber, message.Id, message.ConversationId, template);
+            => new(message.ServiceId, message.UserNumber, message.Id, template);
 
         /// <summary>
         /// Sends an interactive call to action response to the user message.
@@ -57,40 +84,40 @@ public static partial class MessageExtensions
         /// <param name="url">The URL to navigate to when the action button is clicked.</param>
         public CallToActionResponse CallToAction(string text, string action, string url)
             => message is UserMessage user
-            ? new(user.Service, message.UserNumber, text, action, url, message.ConversationId)
-            : new(message.ServiceId, message.UserNumber, text, action, url, message.ConversationId);
+            ? new(user.Service, message.UserNumber, text, action, url)
+            : new(message.ServiceId, message.UserNumber, text, action, url);
 
         /// <summary>
         /// Creates a text reply for the message.
         /// </summary>
         public TextResponse Reply(string text)
             => message is UserMessage user
-            ? new(user.Service, message.UserNumber, message.Id, message.ConversationId, text)
-            : new(message.ServiceId, message.UserNumber, message.Id, message.ConversationId, text);
+            ? new(user.Service, message.UserNumber, message.Id, text)
+            : new(message.ServiceId, message.UserNumber, message.Id, text);
 
         /// <summary>
         /// Creates a text reply with buttons for the message.
         /// </summary>
         public TextResponse Reply(string text, Button button1, Button? button2 = default, Button? button3 = default)
             => message is UserMessage user
-                ? new(user.Service, message.UserNumber, message.Id, message.ConversationId, text, button1, button2, button3)
-                : new(message.ServiceId, message.UserNumber, message.Id, message.ConversationId, text, button1, button2, button3);
+                ? new(user.Service, message.UserNumber, message.Id, text, button1, button2, button3)
+                : new(message.ServiceId, message.UserNumber, message.Id, text, button1, button2, button3);
 
         /// <summary>
         /// Creates a text response for the originating user, but not a message reply.
         /// </summary>
         public TextResponse Send(string text)
             => message is UserMessage user
-            ? new(user.Service, message.UserNumber, null, message.ConversationId, text)
-            : new(message.ServiceId, message.UserNumber, null, message.ConversationId, text);
+            ? new(user.Service, message.UserNumber, null, text)
+            : new(message.ServiceId, message.UserNumber, null, text);
 
         /// <summary>
         /// Creates a text response for the originating user, but not a message reply.
         /// </summary>
         public TextResponse Send(string text, Button button1, Button? button2 = default, Button? button3 = default)
             => message is UserMessage user
-                ? new(user.Service, message.UserNumber, null, message.ConversationId, text, button1, button2, button3)
-                : new(message.ServiceId, message.UserNumber, null, message.ConversationId, text, button1, button2, button3);
+                ? new(user.Service, message.UserNumber, null, text, button1, button2, button3)
+                : new(message.ServiceId, message.UserNumber, null, text, button1, button2, button3);
     }
 
     extension(UserMessage message)
@@ -99,7 +126,7 @@ public static partial class MessageExtensions
         /// Sends a typing indicator status to signal that there is an ongoing response to the user message.
         /// </summary>
         public TypingResponse Typing()
-            => new(message.Service, message.User.Number, message.Id, message.ConversationId);
+            => new(message.Service, message.User.Number, message.Id);
     }
 
     extension<T>(T message) where T : IMessage

--- a/src/WhatsApp/ReactionResponse.cs
+++ b/src/WhatsApp/ReactionResponse.cs
@@ -9,14 +9,14 @@
 /// <param name="UserNumber">The phone number of the recipient in international format.</param>
 /// <param name="Context">The unique identifier of the message to which the reaction is being sent.</param>
 /// <param name="Emoji">The emoji representing the reaction to the message.</param>
-public record ReactionResponse(string ServiceId, string UserNumber, string Context, string? ConversationId, string Emoji) : Response(ServiceId, UserNumber, Context, ConversationId)
+public record ReactionResponse(string ServiceId, string UserNumber, string Context, string Emoji) : Response(ServiceId, UserNumber, Context)
 {
     // If this variable is not null, it means the originating message came from WhatsApp
     // and there's an ongoing conversation with the CLI simultaneously.
     readonly CompositeService? service;
 
-    internal ReactionResponse(Service service, string userNumber, string context, string? conversationId, string emoji)
-        : this(service.Id, userNumber, context, conversationId, emoji)
+    internal ReactionResponse(Service service, string userNumber, string context, string emoji)
+        : this(service.Id, userNumber, context, emoji)
         => this.service = service as CompositeService;
 
     /// <inheritdoc/>

--- a/src/WhatsApp/Response.cs
+++ b/src/WhatsApp/Response.cs
@@ -11,8 +11,7 @@ namespace Devlooped.WhatsApp;
 /// <param name="ServiceId">The identifier of the service to use to send the response through.</param>
 /// <param name="UserNumber">The phone number of the recipient in international format.</param>
 /// <param name="Context">Optional identifier of the message to which this response may be a reply to.</param>
-/// <param name="ConversationId">The conversation id where this response was generated</param>
-public abstract partial record Response(string ServiceId, string UserNumber, string? Context, string? ConversationId) : IMessage
+public abstract partial record Response(string ServiceId, string UserNumber, string? Context) : IMessage
 {
     /// <inheritdoc/>
     [JsonConverter(typeof(AdditionalPropertiesDictionaryConverter))]

--- a/src/WhatsApp/TemplateResponse.cs
+++ b/src/WhatsApp/TemplateResponse.cs
@@ -13,10 +13,10 @@
 /// <param name="Language">The template language code (i.e. 'es_AR')</param>
 /// <see cref="https://developers.facebook.com/docs/whatsapp/api/messages/message-templates#supported-languages"/>
 /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
-public record TemplateResponse(string ServiceId, string UserNumber, string Context, string? ConversationId, object Template) : Response(ServiceId, UserNumber, Context, ConversationId)
+public record TemplateResponse(string ServiceId, string UserNumber, string Context, object Template) : Response(ServiceId, UserNumber, Context)
 {
-    public TemplateResponse(string ServiceId, string UserNumber, string Context, string? ConversationId, string Name, string Language)
-        : this(UserNumber, ServiceId, Context, ConversationId, new { name = Name, language = new { code = Language } })
+    public TemplateResponse(string ServiceId, string UserNumber, string Context, string Name, string Language)
+        : this(UserNumber, ServiceId, Context, new { name = Name, language = new { code = Language } })
     {
     }
 

--- a/src/WhatsApp/TextResponse.cs
+++ b/src/WhatsApp/TextResponse.cs
@@ -21,9 +21,9 @@ public record TextResponse : Response
     /// <param name="text">The text content of the response message.</param>
     /// <param name="button1">An optional button to include in the response for user interaction.</param>
     /// <param name="button2">An optional second button to include in the response for user interaction.</param>
-    /// <param name="button2">An optional third button to include in the response for user interaction.</param>
-    public TextResponse(string serviceId, string userNumber, string? context, string? conversationId, string text, Button? button1 = default, Button? button2 = default, Button? button3 = default)
-        : base(serviceId, userNumber, context, conversationId)
+    /// <param name="button3">An optional third button to include in the response for user interaction.</param>
+    public TextResponse(string serviceId, string userNumber, string? context, string? text, Button? button1 = default, Button? button2 = default, Button? button3 = default)
+        : base(serviceId, userNumber, context)
     {
         sender = context == null ? SendTextAsync : SendReplyAsync;
 
@@ -36,7 +36,7 @@ public record TextResponse : Response
     /// <summary>
     /// Gets or sets the text content of the response message.
     /// </summary>
-    public string Text { get; init; }
+    public string? Text { get; init; }
     /// <summary>
     /// An optional button to include in the response for user interaction.
     /// </summary>
@@ -50,15 +50,15 @@ public record TextResponse : Response
     /// </summary>
     public Button? Button3 { get; init; }
 
-    internal TextResponse(Service service, string userNumber, string? context, string? conversationId, string text, Button? button1 = default, Button? button2 = default, Button? button3 = default)
-        : this(service.Id, userNumber, context, conversationId, text, button1, button2, button3)
+    internal TextResponse(Service service, string userNumber, string? context, string? text, Button? button1 = default, Button? button2 = default, Button? button3 = default)
+        : this(service.Id, userNumber, context, text, button1, button2, button3)
         => this.service = service as CompositeService;
 
     /// <inheritdoc/>
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)
     {
         if (service != null)
-            await sender(client, service.Secondary.Id, this.ConsoleText ?? Text, cancellation);
+            await sender(client, service.Secondary.Id, this.ConsoleText ?? Text ?? "", cancellation);
 
         // If service is null, it's either a WhatsApp regular without CLI, or it's pure CLI.
         // In the former case, we don't want to send messages that are CLI-only if the service id 
@@ -69,7 +69,7 @@ public record TextResponse : Response
         // It may not be CLI-only but still provide a CLI-enhanced text.
         return await sender(client, ServiceId,
             // Automatically pick the CLI version of the text if sending to the CLI
-            ServiceId.IsCLI() ? this.ConsoleText ?? Text : Text, cancellation);
+            ServiceId.IsCLI() ? this.ConsoleText ?? Text ?? "" : Text ?? "", cancellation);
     }
 
     Task<string?> SendReplyAsync(IWhatsAppClient client, string serviceId, string text, CancellationToken cancellation)

--- a/src/WhatsApp/TypingResponse.cs
+++ b/src/WhatsApp/TypingResponse.cs
@@ -4,12 +4,12 @@
 /// Represents a typing status update that can be sent in response to a user message.
 /// </summary>
 /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/typing-indicators"/>
-public record TypingResponse(string ServiceId, string UserNumber, string Context, string? ConversationId) : Response(ServiceId, UserNumber, Context, ConversationId)
+public record TypingResponse(string ServiceId, string UserNumber, string Context) : Response(ServiceId, UserNumber, Context)
 {
     readonly CompositeService? service;
 
-    internal TypingResponse(Service service, string userNumber, string context, string? conversationId)
-        : this(service.Id, userNumber, context, conversationId)
+    internal TypingResponse(Service service, string userNumber, string context)
+        : this(service.Id, userNumber, context)
         => this.service = service as CompositeService;
 
     protected override async Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default)


### PR DESCRIPTION
The concept of a conversation id is not built-in WhatsApp, and therefore we should not force it on the basic API.

It's rather a concept we implement specifically as part of the conversation storage and handler, which are entirely optional.

With extension properties, we can make it seamless to use yet not tied to the core interfaces, since we support AdditionalProperties to support precisely this kind of extensibility scenarios.