### PR TITLE
Allow polymorphic serialization for anonymous responses

### DIFF
--- a/src/Tests/WhatsAppModelTests.cs
+++ b/src/Tests/WhatsAppModelTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Devlooped.WhatsApp;
+﻿using System.Text.Json;
+
+namespace Devlooped.WhatsApp;
 
 public class WhatsAppModelTests(ITestOutputHelper output)
 {
@@ -175,5 +177,18 @@ public class WhatsAppModelTests(ITestOutputHelper output)
         Assert.NotNull(message.Service);
         Assert.NotNull(message.User);
         Assert.Equal("😊", reaction.Emoji);
+    }
+
+    [Fact]
+    public void SerializeAnonymous()
+    {
+        var response = Response.Create("123456789012345", "987654321098765", (client, cancellation) => Task.FromResult<string?>(null));
+
+        var json = JsonSerializer.Serialize(response, JsonContext.DefaultOptions);
+
+        var message = JsonSerializer.Deserialize(json, JsonContext.Default.AnonymousResponse);
+
+        Assert.NotNull(message);
+        Assert.Null(message.Sender);
     }
 }

--- a/src/WhatsApp/AnonymousResponse.cs
+++ b/src/WhatsApp/AnonymousResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Devlooped.WhatsApp;
+﻿using System.Text.Json.Serialization;
+
+namespace Devlooped.WhatsApp;
 
 /// <summary>
 /// A response that uses a function to send the message.
@@ -14,6 +16,11 @@ public record AnonymousResponse(string ServiceId, string UserNumber, Func<IWhats
     /// </summary>
     public AnonymousResponse(IMessage message, Func<IWhatsAppClient, CancellationToken, Task<string?>> sender)
         : this(message.ServiceId, message.UserNumber, sender) { }
+
+    [JsonConstructor]
+    internal AnonymousResponse(string ServiceId, string UserNumber) : this(ServiceId, UserNumber, (client, cancellation) => Task.FromResult<string?>(null))
+    {
+    }
 
     protected override Task<string?> SendCoreAsync(IWhatsAppClient client, CancellationToken cancellation = default) => Sender(client, cancellation);
 }

--- a/src/WhatsApp/IMessage.cs
+++ b/src/WhatsApp/IMessage.cs
@@ -22,6 +22,7 @@ namespace Devlooped.WhatsApp;
 [JsonDerivedType(typeof(ReactionResponse), "response/reaction")]
 [JsonDerivedType(typeof(TypingResponse), "response/typing")]
 [JsonDerivedType(typeof(CallToActionResponse), "response/cta")]
+[JsonDerivedType(typeof(AnonymousResponse), "response/dynamic")]
 public interface IMessage
 {
     /// <summary>Gets or sets any additional properties associated with the message.</summary>


### PR DESCRIPTION
The delegate is obviously lost when serializing, but still works to keep track of sent responses if storage is used.