### PR TITLE
Avoid polluting other Test projects with internals from WhatsApp

### DIFF
--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Preview</LangVersion>
-
+    <AssemblyName>Devlooped.WhatsApp.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/WhatsApp/WhatsApp.csproj
+++ b/src/WhatsApp/WhatsApp.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Tests" />
+    <InternalsVisibleTo Include="Devlooped.WhatsApp.Tests" />
     <EmbeddedResource Include="Message.jq" Kind="Text" />
   </ItemGroup>
 


### PR DESCRIPTION
Make the tests project fully qualified so we avoid exposing internals to other projects that are simply named Tests too by chance.