### PR TITLE
In development, run in a separate thread from webhook

### DIFF
--- a/src/WhatsApp/AzureFunctionsWebhook.cs
+++ b/src/WhatsApp/AzureFunctionsWebhook.cs
@@ -133,11 +133,25 @@ class AzureFunctionsWebhook(
                 await message.React(functionOptions.ReactOnMessage).SendAsync(whatsapp).Ignore();
 
             if (hosting.IsDevelopment())
-                // Process inline to speed up local devloop
-                await runner.ProcessAsync(json);
+            {
+                // Avoid enqueing to speed up local devloop
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await runner.ProcessAsync(json);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(e, "Failed to process message");
+                    }
+                });
+            }
             else
+            {
                 // Otherwise, enqueue the message processing
                 await messageProcessor.EnqueueAsync(json);
+            }
         }
         else
         {


### PR DESCRIPTION
The webhook needs to return almost immediately always, otherwise WhatsApp will start duplicating the calls.