### PR TITLE
Preserve relaxed JSON encoding

### DIFF
--- a/src/Tests/FlowTests.cs
+++ b/src/Tests/FlowTests.cs
@@ -21,6 +21,15 @@ namespace Devlooped.WhatsApp;
 
 public class FlowTests(ITestOutputHelper output)
 {
+    static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition =
+            System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault |
+            System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = true,
+    };
+
     [Fact]
     public void VerifyFlowRequest()
     {
@@ -108,11 +117,11 @@ public class FlowTests(ITestOutputHelper output)
                 data = new
                 {
                     agent = "list",
-                    service = "5678",
-                    user = "pga",
+                    service = "5678📝🧮",
+                    user = "pgaña",
                     flow = "data",
                 },
-            })
+            }, jsonOptions)
         });
 
         var sent = await response.SendAsync(client);

--- a/src/WhatsApp/WhatsAppClient.cs
+++ b/src/WhatsApp/WhatsAppClient.cs
@@ -73,7 +73,7 @@ public class WhatsAppClient(IHttpClientFactory httpFactory, IOptions<MetaOptions
         http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {token}");
         http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-        var result = await http.PostAsJsonAsync($"https://graph.facebook.com/{options.ApiVersion}/{numberId}/messages", payload, cancellationToken);
+        var result = await http.PostAsJsonAsync($"https://graph.facebook.com/{options.ApiVersion}/{numberId}/messages", payload, jsonOptions, cancellationToken);
 
         if (!result.IsSuccessStatusCode)
         {


### PR DESCRIPTION
Otherwise we may lose unicode text due to unnecessray escaping.