### PR TITLE
Default to typing on process too

### DIFF
--- a/src/WhatsApp/WhatsAppOptions.cs
+++ b/src/WhatsApp/WhatsAppOptions.cs
@@ -31,7 +31,7 @@ public class WhatsAppOptions
     /// <summary>
     /// Send a typing indicator status when message processing begins.
     /// </summary>
-    public bool? TypingOnProcess { get; set; }
+    public bool? TypingOnProcess { get; set; } = true;
 
     /// <summary>
     /// An optional emoji to react with when a message is received 


### PR DESCRIPTION
Since the split between message/process might take a bit (i.e. while the processing endpoint spins-up), we should add the typing indicator back again)