### PR TITLE
Allow inspecting the originating JSON for a message

### DIFF
--- a/src/Tests/WhatsAppModelTests.cs
+++ b/src/Tests/WhatsAppModelTests.cs
@@ -29,7 +29,7 @@ public class WhatsAppModelTests(ITestOutputHelper output)
         // If id was empty, it should be automatically fixed and generated
         if (id == string.Empty)
         {
-            Assert.False(string.IsNullOrEmpty(message.Id));
+            Assert.False(string.IsNullOrEmpty(message.Id)); ;
         }
         else
         {

--- a/src/WhatsApp/AdditionalPropertiesDictionaryConverter.cs
+++ b/src/WhatsApp/AdditionalPropertiesDictionaryConverter.cs
@@ -38,7 +38,7 @@ partial class AdditionalPropertiesDictionaryConverter : JsonConverter<Additional
     {
         writer.WriteStartObject();
 
-        foreach (var kvp in value.Where(x => x.Value is not null))
+        foreach (var kvp in value.Where(x => x.Value is not null && !x.Key.StartsWith("__", StringComparison.Ordinal)))
         {
             writer.WritePropertyName(kvp.Key);
             JsonSerializer.Serialize(writer, kvp.Value, options);

--- a/src/WhatsApp/Message.cs
+++ b/src/WhatsApp/Message.cs
@@ -21,6 +21,9 @@ namespace Devlooped.WhatsApp;
 [JsonDerivedType(typeof(UnsupportedMessage), "unsupported")]
 public abstract partial record Message(string Id, Service Service, User User, long Timestamp) : IMessage
 {
+    /// <summary>For debugging purposes, exposes the original JSON used to deserialize this instance, if any.</summary>
+    internal string? Json => AdditionalProperties?.GetValueOrDefault("__json") as string;
+
     /// <inheritdoc/>
     [JsonConverter(typeof(AdditionalPropertiesDictionaryConverter))]
     public AdditionalPropertiesDictionary? AdditionalProperties { get; set; }
@@ -59,10 +62,14 @@ public abstract partial record Message(string Id, Service Service, User User, lo
         {
             var message = JsonSerializer.Deserialize<Message>(jq, JsonContext.DefaultOptions);
 
-            // Fix empty id for system messages
-            if (message is not null && string.IsNullOrEmpty(message.Id))
+            if (message is not null)
             {
-                message = message with { Id = Ulid.NewUlid().ToString() };
+                message.AdditionalProperties ??= [];
+                message.AdditionalProperties["__json"] = json;
+
+                // Fix empty id for system messages that don't have a message id otherwise
+                if (string.IsNullOrEmpty(message.Id))
+                    message = message with { Id = Ulid.NewUlid().ToString() };
             }
 
             return message;


### PR DESCRIPTION
Allow inspecting the originating JSON for a message

Introduce non-serializable keys in the additional properties dictionary for messages (those that start with `__`) so that apps can leverage them for internal-only, transient data that doesn't need serialization at all.

Then right after deserializing a message, place the originating JSON as-is in that dictionary as `__json` and expose as internal property for debugging purposes. Note we explicitly don't make this part of the public API (for now?).