### PR TITLE
Allow invoking the processing behavior directly via HTTP POST

### DIFF
--- a/src/WhatsApp/AzureFunctionsProcessors.cs
+++ b/src/WhatsApp/AzureFunctionsProcessors.cs
@@ -1,12 +1,17 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 using Azure.Messaging.EventGrid;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Options;
 
 namespace Devlooped.WhatsApp;
 
-class AzureFunctionsProcessors(PipelineRunner runner)
+class AzureFunctionsProcessors(PipelineRunner runner, IOptions<WhatsAppOptions> options)
 {
+    readonly WhatsAppOptions options = options.Value;
+
     [Function("whatsapp_dequeue")]
     public Task DequeueAsync([QueueTrigger("whatsappwebhook", Connection = "AzureWebJobsStorage")] string json)
         => runner.ProcessAsync(json);
@@ -21,6 +26,22 @@ class AzureFunctionsProcessors(PipelineRunner runner)
 #endif
     {
         await runner.ProcessAsync(Regex.Unescape(e.Data.ToString()).Trim('"'));
+        return new OkResult();
+    }
+
+    [Function("whatsapp_process")]
+    public async Task<IActionResult> ProcessAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequest req)
+    {
+        if (string.IsNullOrEmpty(options.Secret) ||
+            !req.Headers.TryGetValue("X-WHATSAPP-SECRET", out var values) ||
+            !options.Secret.Equals(values.ToString(), StringComparison.Ordinal))
+            return new UnauthorizedResult();
+
+        using var reader = new StreamReader(req.Body, Encoding.UTF8);
+        var json = await reader.ReadToEndAsync();
+
+        await runner.ProcessAsync(json);
         return new OkResult();
     }
 }

--- a/src/WhatsApp/WhatsAppOptions.cs
+++ b/src/WhatsApp/WhatsAppOptions.cs
@@ -48,4 +48,14 @@ public class WhatsAppOptions
     /// An optional emoji to react with when restoring conversation context.
     /// </summary>
     public string? ReactOnConversation { get; set; }
+
+    /// <summary>
+    /// Optional secret to enable direct POST processing of webhook-formatted 
+    /// payloads without going through a queue. 
+    /// </summary>
+    /// <remarks>
+    /// If used, the incoming POST request must have the X-WHATSAPP-SECRET 
+    /// header set and it must match exactly the value of this option.
+    /// </remarks>
+    public string? Secret { get; set; }
 }


### PR DESCRIPTION
Allow invoking the processing behavior directly via HTTP POST

This can come in handy as a webhook-style mechanism that allows other arbitrary external queue/retry mechanisms to be implemented without requiring further changes to this library.

The only difference with the regular whatsapp_message endpoint is that the new whatsapp_process endpoint invokes the processing directly without doing any queuing whatesoever.