### PR TITLE
Improve URL paths for sub-commands

### DIFF
--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -33,7 +33,7 @@ partial class Interactive(IConfiguration configuration, IHttpClientFactory httpF
     {
         if (string.IsNullOrEmpty(service))
         {
-            service = AnsiConsole.Ask("Enter WhatsApp functions endpoint", "http://localhost:4242/whatsappcli");
+            service = AnsiConsole.Ask("Enter WhatsApp functions endpoint", "http://localhost:4242/whatsapp/cli");
             Config.Build(ConfigLevel.Global)
                 .SetString("whatsapp", "endpoint", service);
         }

--- a/src/WhatsApp/AzureFunctionsConsole.cs
+++ b/src/WhatsApp/AzureFunctionsConsole.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using System.Text.Json;
-using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -25,10 +24,13 @@ class AzureFunctionsConsole(
         WriteIndented = true
     };
 
-    [Function("whatsapp_console")]
-    public async Task<IActionResult> MessageConsole([HttpTrigger(AuthorizationLevel.Anonymous, ["post", "get"], Route = "whatsappcli")] HttpRequest req)
-    {
+    [Function("whatsapp_console_legacy")]
+    public IActionResult MessageConsoleLegacy([HttpTrigger(AuthorizationLevel.Anonymous, ["post", "get"], Route = "whatsappcli")] HttpRequest req)
+        => new RedirectResult(req.Path.Value.Replace("whatsappcli", "whatsapp/cli"), true, true);
 
+    [Function("whatsapp_console")]
+    public async Task<IActionResult> MessageConsole([HttpTrigger(AuthorizationLevel.Anonymous, ["post", "get"], Route = "whatsapp/cli")] HttpRequest req)
+    {
         // This endpoint is only available in development environments, since it allows sending messages from the debug console.
         if (environment.IsProduction())
             return new UnauthorizedResult();

--- a/src/WhatsApp/AzureFunctionsProcessors.cs
+++ b/src/WhatsApp/AzureFunctionsProcessors.cs
@@ -21,7 +21,7 @@ class AzureFunctionsProcessors(PipelineRunner runner, IOptions<WhatsAppOptions> 
 #if CI || RELEASE
         [EventGridTrigger] EventGridEvent e)
 #else
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp/eventgrid")]
         [Microsoft.Azure.Functions.Worker.Http.FromBody] EventGridEvent e)
 #endif
     {
@@ -31,7 +31,7 @@ class AzureFunctionsProcessors(PipelineRunner runner, IOptions<WhatsAppOptions> 
 
     [Function("whatsapp_process")]
     public async Task<IActionResult> ProcessAsync(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequest req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp/process")] HttpRequest req)
     {
         if (string.IsNullOrEmpty(options.Secret) ||
             !req.Headers.TryGetValue("X-WHATSAPP-SECRET", out var values) ||


### PR DESCRIPTION
The main webhook route remains the same, but in order to avoid poluting the root path, we add / separator for cli, process and locally run eventgrid (via HTTP).

For now we keep the backwards-compatible /whatsappcli endpoint for older CLIs so they can continue to work but permanently redirecting to the new endpoint.