### PR TITLE
Allow dev processing event grid as webhook subscription

### DIFF
--- a/src/SampleApp/Sample/Program.cs
+++ b/src/SampleApp/Sample/Program.cs
@@ -75,7 +75,8 @@ if (builder.Environment.IsProduction())
         builder.Configuration["EventGrid:Key"] is { Length: > 0 } key)
     {
         whatsapp.UseEventGridProcessor(new EventGridPublisherClient(
-            new Uri(topic), new Azure.AzureKeyCredential(key)));
+            new Uri(topic), new Azure.AzureKeyCredential(key)),
+            options => builder.Configuration.Bind("EventGrid", options));
     }
 }
 else

--- a/src/WhatsApp/AzureFunctionsProcessors.cs
+++ b/src/WhatsApp/AzureFunctionsProcessors.cs
@@ -16,18 +16,43 @@ class AzureFunctionsProcessors(Func<PipelineRunner> runner, IOptions<WhatsAppOpt
     public Task DequeueAsync([QueueTrigger("whatsappwebhook", Connection = "AzureWebJobsStorage")] string json)
         => runner().ProcessAsync(json);
 
+#if CI || RELEASE
     [Function("whatsapp_eventgrid")]
     public async Task<IActionResult> HandleEventGrid(
-#if CI || RELEASE
         [EventGridTrigger] EventGridEvent e)
-#else
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp/eventgrid")]
-        [Microsoft.Azure.Functions.Worker.Http.FromBody] EventGridEvent e)
-#endif
     {
         await runner().ProcessAsync(Regex.Unescape(e.Data.ToString()).Trim('"'));
         return new OkResult();
     }
+#else
+    [Function("whatsapp_eventgrid")]
+    public async Task<IActionResult> HandleEventGrid(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp/eventgrid")] HttpRequest request)
+    {
+        using var sr = new StreamReader(request.Body);
+        var json = await sr.ReadToEndAsync();
+        var events = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject[]>(json);
+
+        // Validation handshake?
+        if (request.Headers.TryGetValue("aeg-event-type", out var aeg) && aeg.ToString() == "SubscriptionValidation" &&
+            events?[0]?["data"]?["validationCode"]?.ToString() is string code)
+        {
+            return new OkObjectResult(new { validationResponse = code }); // 200 with the code
+        }
+
+        // Normal events here...
+        var data = System.Text.Json.JsonSerializer.Deserialize<EventGridEvent[]>(json);
+        if (data == null)
+            return new OkResult();
+
+        foreach (var item in data)
+        {
+            await runner().ProcessAsync(Regex.Unescape(item.Data.ToString()).Trim('"'));
+        }
+
+        return new OkResult();
+    }
+#endif
 
     [Function("whatsapp_process")]
     public async Task<IActionResult> ProcessAsync(

--- a/src/WhatsApp/EventGridProcessorExtensions.cs
+++ b/src/WhatsApp/EventGridProcessorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Messaging.EventGrid;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Devlooped.WhatsApp;
 
@@ -27,7 +28,7 @@ public static class EventGridProcessorExtensions
 
         builder.Services.AddSingleton<IMessageProcessor>(services =>
         {
-            var options = new EventGridOptions();
+            var options = services.GetService<IOptions<EventGridOptions>>()?.Value ?? new();
             configure?.Invoke(options);
             return new EventGridProcessor(publisher ??
                 services.GetRequiredService<EventGridPublisherClient>(),


### PR DESCRIPTION
Allow dev processing event grid as webhook subscription

This allows a more realistic end to end testing leveraging the EventGrid settings if present and running as production even locally.

Configuration on the EventGrid Subscription should use Web Hook configuration and the /whatsapp/eventgrid endpoint that is exposed in this case (only for non-CI/Release builds).