### PR TITLE
Validate Meta options/config on startup rather than run-time

### DIFF
--- a/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
+++ b/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
@@ -256,7 +256,7 @@ static class WhatsAppServiceCollectionExtensions
                 services.GetRequiredService<IConfiguration>()["AzureWebJobsStorage"]!));
         }
 
-        services.AddOptions<MetaOptions>()
+        builder.Services.AddOptionsWithValidateOnStart<MetaOptions>()
             .BindConfiguration("Meta")
             .ValidateDataAnnotations();
 


### PR DESCRIPTION
Validate Meta options/config on startup rather than run-time

This makes it easier to troubleshoot missing settings.