### PR TITLE
Nest phone numbers inside their parent WhatsApp Business Accounts in MetaOptions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,8 +257,12 @@ as follows:
 ```csharp
 builder.Services.Configure<MetaOptions>(options =>
 {
-    options.VerifyToken = "my-webhook-1234";
-    options.Numbers["12345678"] = "asff=";
+    options.Accounts["123456"] = new AccountOptions
+    {
+        AccessToken = "asff=",
+        VerifyToken = "my-webhook-1234",
+        Numbers = ["12345678", "98765432"]
+    };
 });
 ```
 
@@ -267,18 +271,51 @@ Via configuration:
 ```json
 {
   "Meta": {
-    "VerifyToken": "my-webhook-1234",
-    "Numbers": {
-      "12345678": "asff="
+    "Accounts": {
+      "123456": {
+        "AccessToken": "asff=",
+        "VerifyToken": "my-webhook-1234",
+        "Numbers": ["12345678", "98765432"]
+      }
     }
   }
 }
 ```
 
-The `Numbers` dictionary is a map of WhatsApp phone identifiers and the 
-corresponding access token for it. To get a permanent access token for 
-use, you'd need to create a [system user](https://business.facebook.com/latest/settings/system_users) 
-with full control permissions to the WhatsApp Business API (app).
+The `Accounts` dictionary maps WhatsApp Business Account (WABA) IDs to their settings. 
+Each account has:
+- `AccessToken` — the access token used for both messaging and Flows management API calls. 
+  To get a permanent access token, create a [system user](https://business.facebook.com/latest/settings/system_users) 
+  with full control permissions to the WhatsApp Business API (app).
+- `VerifyToken` — an arbitrary string you choose when registering the webhook in the 
+  [Meta App Dashboard](https://developers.facebook.com/apps/) under WhatsApp > Configuration.
+- `Numbers` — list of phone number IDs belonging to this account. All share the account's access token.
+- `PrivateKey` *(optional)* — RSA private key (PEM format) for decrypting WhatsApp Flows data exchange requests.
+
+Multiple accounts can be configured simultaneously, enabling a single deployment to serve 
+several WhatsApp Business Accounts:
+
+```json
+{
+  "Meta": {
+    "Accounts": {
+      "111111": {
+        "AccessToken": "token-a",
+        "VerifyToken": "verify-a",
+        "Numbers": ["10000001"]
+      },
+      "222222": {
+        "AccessToken": "token-b",
+        "VerifyToken": "verify-b",
+        "Numbers": ["20000001", "20000002"]
+      }
+    }
+  }
+}
+```
+
+When using multiple accounts, each account registers its own webhook at 
+`/whatsapp/{accountId}` in addition to the default `/whatsapp` endpoint.
 
 You can also configure how the WhatsApp webhook and processing pipeline behaves by passing 
 in an additional delegate to the `AddWhatsApp` method via the `configure` parameter:

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Console": {
       "commandName": "Project",
-      "commandLineArgs": ""
+      "commandLineArgs": "--url https://localhost:7254/whatsapp/cli"
     }
   }
 }

--- a/src/Tests/FlowTests.cs
+++ b/src/Tests/FlowTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Devlooped.WhatsApp.Flows;
@@ -74,7 +74,7 @@ public class FlowTests(ITestOutputHelper output)
         Assert.NotEmpty(encryptedResponse);
     }
 
-    [SecretsFact("Meta:PrivateKey", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendFlowListPayload()
     {
         var (configuration, client) = Initialize();
@@ -109,7 +109,7 @@ public class FlowTests(ITestOutputHelper output)
         Assert.NotEqual(response, sent);
     }
 
-    [SecretsFact("Meta:PrivateKey", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendFlowNavigateData()
     {
         var (configuration, client) = Initialize();
@@ -140,7 +140,7 @@ public class FlowTests(ITestOutputHelper output)
         Assert.NotEqual(response, sent);
     }
 
-    [SecretsFact("Meta:PrivateKey", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendBlankNavigate()
     {
         var (configuration, client) = Initialize();
@@ -154,7 +154,7 @@ public class FlowTests(ITestOutputHelper output)
         Assert.NotEqual(response, sent);
     }
 
-    [SecretsFact("Meta:PrivateKey")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendFlowWithData()
     {
         var (configuration, client) = Initialize();
@@ -340,7 +340,7 @@ public class FlowTests(ITestOutputHelper output)
         Assert.Equal("bar", message.Data.GetProperty("foo").GetString());
     }
 
-    [SecretsFact("Meta:Accounts:539235785933710")]
+    [SecretsFact("Meta:Accounts:539235785933710:AccessToken")]
     public async Task ListFlows()
     {
         var (_, client) = Initialize();
@@ -350,7 +350,7 @@ public class FlowTests(ITestOutputHelper output)
     }
 
 
-    [SecretsTheory("Meta:Accounts:539235785933710")]
+    [SecretsTheory("Meta:Accounts:539235785933710:AccessToken")]
     [InlineData("539235785933710")]
     public async Task FlowCrud(string accountId)
     {

--- a/src/Tests/IntegrationTests.cs
+++ b/src/Tests/IntegrationTests.cs
@@ -31,9 +31,9 @@ public class IntegrationTests : IDisposable
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:VerifyToken", "test-challenge" },
-                { "Meta:Accounts:1234567890", "test-access-token" },
-                { "Meta:Numbers:1234567890", "test-access-token" }
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers:0", "1234567890" }
             })
             .Build();
 

--- a/src/Tests/MetaOptionsTests.cs
+++ b/src/Tests/MetaOptionsTests.cs
@@ -13,9 +13,9 @@ public class MetaOptionsTests
             .AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:VerifyToken", "test-challenge" },
-                { "Meta:Accounts:1234567890", "test-access-token" },
-                { "Meta:Numbers:1234567890", "test-access-token" }
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers:0", "1234567890" }
             }).Build());
 
         collection.AddOptions<MetaOptions>()
@@ -27,45 +27,33 @@ public class MetaOptionsTests
             .GetRequiredService<IOptions<MetaOptions>>().Value;
 
         Assert.NotNull(options);
-        Assert.Equal("test-challenge", options.VerifyToken);
-        Assert.Equal("test-access-token", options.Numbers["1234567890"]);
-        Assert.Equal("test-access-token", options.Accounts["1234567890"]);
+        Assert.Equal("test-challenge", options.GetVerifyToken("1234567890"));
+        Assert.Equal("test-access-token", options.GetToken("1234567890"));
         Assert.Equal("v22.0", options.ApiVersion);
     }
 
     [Fact]
-    public void FailsWithoutChallenge()
+    public void FindAccountByVerifyTokenReturnsNullForUnknownToken()
     {
-        var collection = new ServiceCollection()
-            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>()
+        var options = new MetaOptions
+        {
+            Accounts = new Dictionary<string, AccountOptions>
             {
-                { "Meta:Accounts:1234567890", "test-access-token" },
-                { "Meta:Numbers:1234567890", "test-access-token" }
-            }).Build());
+                ["1234"] = new AccountOptions { AccessToken = "tok", VerifyToken = "known-token", Numbers = ["9876"] }
+            }
+        };
 
-        collection.AddOptions<MetaOptions>()
-            .BindConfiguration("Meta")
-            .ValidateDataAnnotations();
-
-        var ex = Assert.Throws<OptionsValidationException>(() => collection
-            .BuildServiceProvider()
-            .GetRequiredService<IOptions<MetaOptions>>().Value);
-
-        Assert.Single(ex.Failures);
-        Assert.Contains(nameof(MetaOptions), ex.Failures.First());
-        Assert.Contains(nameof(MetaOptions.VerifyToken), ex.Failures.First());
+        Assert.Null(options.FindAccountByVerifyToken("unknown-token"));
+        Assert.Equal("1234", options.FindAccountByVerifyToken("known-token"));
     }
 
     [Fact]
-    public void FailsWithoutNumbers()
+    public void FailsWithoutAccounts()
     {
         var collection = new ServiceCollection()
             .AddSingleton<IConfiguration>(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:Accounts:1234567890", "test-access-token" },
-                { "Meta:VerifyToken", "test-challenge" },
             }).Build());
 
         collection.AddOptions<MetaOptions>()
@@ -78,7 +66,22 @@ public class MetaOptionsTests
 
         Assert.Single(ex.Failures);
         Assert.Contains(nameof(MetaOptions), ex.Failures.First());
-        Assert.Contains(nameof(MetaOptions.Numbers), ex.Failures.First());
+        Assert.Contains(nameof(MetaOptions.Accounts), ex.Failures.First());
+    }
+
+    [Fact]
+    public void GetTokenReturnsNullForUnknownNumber()
+    {
+        var options = new MetaOptions
+        {
+            Accounts = new Dictionary<string, AccountOptions>
+            {
+                ["1234"] = new AccountOptions { AccessToken = "tok", VerifyToken = "vt", Numbers = ["9876"] }
+            }
+        };
+
+        Assert.Null(options.GetToken("0000"));
+        Assert.Equal("tok", options.GetToken("9876"));
     }
 
 }

--- a/src/Tests/PipelineTests.cs
+++ b/src/Tests/PipelineTests.cs
@@ -84,8 +84,9 @@ public class PipelineTests(ITestOutputHelper output)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:VerifyToken", "test-challenge" },
-                { "Meta:Numbers:1234567890", "test-access-token" }
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers:0", "1234567890" }
             })
             .Build();
 
@@ -161,8 +162,9 @@ public class PipelineTests(ITestOutputHelper output)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:VerifyToken", "test-challenge" },
-                { "Meta:Numbers:1234567890", "test-access-token" }
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers:0", "1234567890" }
             })
             .Build();
 
@@ -224,8 +226,9 @@ public class PipelineTests(ITestOutputHelper output)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>()
             {
-                { "Meta:VerifyToken", "test-challenge" },
-                { "Meta:Numbers:1234", "test-access-token" }
+                { "Meta:Accounts:1234:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234:Numbers:0", "1234" }
             })
             .Build();
 

--- a/src/Tests/WhatsAppClientTests.cs
+++ b/src/Tests/WhatsAppClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,7 +12,6 @@ public class WhatsAppClientTests(ITestOutputHelper output)
     {
         var client = WhatsAppClient.Create(MockHttpClientFactory.Default, new MetaOptions
         {
-            VerifyToken = "asdf"
         }, MockLogger.Create<WhatsAppClient>());
 
         var ex = await Assert.ThrowsAsync<ArgumentException>(() => client.SendAsync("1234", new { }));
@@ -20,7 +19,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         Assert.Equal("numberId", ex.ParamName);
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsMessageAsync()
     {
         var (configuration, client) = Initialize();
@@ -31,7 +30,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         Assert.NotEmpty(id);
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task ReactToSentMessageAsync()
     {
         var (configuration, client) = Initialize();
@@ -44,7 +43,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         await client.ReactAsync(configuration["SendFrom"]!, configuration["SendTo"]!, id, "🙏");
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task ReplyToSentMessageAsync()
     {
         var (configuration, client) = Initialize();
@@ -68,7 +67,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         Assert.NotEqual(id, reply);
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsButtonAsync()
     {
         var (configuration, client) = Initialize();
@@ -100,7 +99,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsListAsync()
     {
         var (configuration, client) = Initialize();
@@ -160,7 +159,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplateAsync()
     {
         var (configuration, client) = Initialize();
@@ -175,7 +174,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplateMeetingAsync()
     {
         var (configuration, client) = Initialize();
@@ -192,7 +191,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplate2Async()
     {
         var (configuration, client) = Initialize();
@@ -209,7 +208,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplateUrlAsync()
     {
         var (configuration, client) = Initialize();
@@ -229,7 +228,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplateButtonsAsync()
     {
         var (configuration, client) = Initialize();
@@ -249,7 +248,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsCallToActionAsync()
     {
         var (configuration, client) = Initialize();
@@ -282,7 +281,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         });
     }
 
-    [SecretsFact("Meta:VerifyToken", "MediaTo", Skip = "Media attachments are deleted if user deletes them, so skip.")]
+    [SecretsFact("MediaTo", Skip = "Media attachments are deleted if user deletes them, so skip.")]
     public async Task ResolvesMediaIdFromHttpClient()
     {
         var (configuration, client) = Initialize();
@@ -297,7 +296,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         await stream.CopyToAsync(fs);
     }
 
-    [SecretsFact("Meta:VerifyToken", "MediaTo", Skip = "Media are transient and therefore this test requires an active message present")]
+    [SecretsFact("MediaTo", Skip = "Media are transient and therefore this test requires an active message present")]
     public async Task ResolveMediaThrowsForNonExistentId()
     {
         var (configuration, client) = Initialize();
@@ -309,7 +308,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
         Assert.Equal(33, ex.Subcode);
     }
 
-    [SecretsFact("Meta:VerifyToken", "MediaTo")]
+    [SecretsFact("MediaTo")]
     public async Task ResolveMediaThrowsForNonMediaMessage()
     {
         var (configuration, client) = Initialize();
@@ -319,7 +318,7 @@ public class WhatsAppClientTests(ITestOutputHelper output)
                 new UnknownContent(new System.Text.Json.JsonElement()))));
     }
 
-    [SecretsFact("Meta:VerifyToken", "SendFrom", "SendTo")]
+    [SecretsFact("SendFrom", "SendTo")]
     public async Task SendsTemplateWithMessageTemplateObjectAsync()
     {
         var (configuration, client) = Initialize();

--- a/src/WhatsApp.AspNetCore/WhatsAppEndpointRouteBuilderExtensions.cs
+++ b/src/WhatsApp.AspNetCore/WhatsAppEndpointRouteBuilderExtensions.cs
@@ -48,9 +48,11 @@ public static class WhatsAppEndpointRouteBuilderExtensions
 
         // POST /whatsapp - Main webhook endpoint for receiving messages
         endpoints.MapPost("/whatsapp", HandleMessageAsync);
+        endpoints.MapPost("/whatsapp/{accountId}", HandleMessageAsync);
 
         // GET /whatsapp - Webhook verification endpoint
         endpoints.MapGet("/whatsapp", HandleRegisterAsync);
+        endpoints.MapGet("/whatsapp/{accountId}", HandleRegisterAsync);
 
         // POST /whatsapp/process - Direct message processing endpoint
         endpoints.MapPost("/whatsapp/process", HandleProcessAsync);
@@ -79,7 +81,8 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         IOptions<WhatsAppOptions> whatsappOptions,
         IHostEnvironment hosting,
         Func<IWhatsAppHandler> handlerFactory,
-        ILogger<WhatsAppEndpoints> logger)
+        ILogger<WhatsAppEndpoints> logger,
+        string? accountId = null)
     {
         var json = body.GetRawText();
 
@@ -90,7 +93,7 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         // Detect encrypted flow request setup for flows endpoints
         if (JsonSerializer.Deserialize<EncryptedFlowData>(json) is { Data.Length: > 0, IV.Length: > 0, Key.Length: > 0 } encrypted)
         {
-            return await ProcessFlowDataAsync(json, encrypted, metaOptions.Value, handlerFactory(), logger);
+            return await ProcessFlowDataAsync(json, encrypted, metaOptions.Value, handlerFactory(), logger, accountId);
         }
 
         if (await Message.DeserializeAsync(json) is { } message)
@@ -113,14 +116,37 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         return Results.Ok();
     }
 
-    static async Task<IResult> ProcessFlowDataAsync(string json, EncryptedFlowData encrypted, MetaOptions metaOptions, IWhatsAppHandler handler, ILogger logger)
+    static async Task<IResult> ProcessFlowDataAsync(string json, EncryptedFlowData encrypted, MetaOptions metaOptions, IWhatsAppHandler handler, ILogger logger, string? accountId = null)
     {
-        if (string.IsNullOrEmpty(metaOptions.PrivateKey))
-            return Results.StatusCode(421);
+        FlowCryptography? crypto = null;
+        FlowData? data = null;
 
-        var crypto = new FlowCryptography(metaOptions.PrivateKey);
-        if (!crypto.TryDecrypt(encrypted, out var data) || data is null)
-            return Results.StatusCode(421);
+        if (accountId is not null)
+        {
+            var key = metaOptions.GetPrivateKey(accountId);
+            if (key is null)
+                return Results.StatusCode(421);
+
+            crypto = new FlowCryptography(key);
+            if (!crypto.TryDecrypt(encrypted, out data) || data is null)
+                return Results.StatusCode(421);
+        }
+        else
+        {
+            foreach (var key in metaOptions.GetPrivateKeys())
+            {
+                var candidate = new FlowCryptography(key);
+                if (candidate.TryDecrypt(encrypted, out data) && data is not null)
+                {
+                    crypto = candidate;
+                    break;
+                }
+                candidate.Dispose();
+            }
+
+            if (crypto is null || data is null)
+                return Results.StatusCode(421);
+        }
 
         if (data.Data.TryGetProperty("action", out var action) &&
             action.ValueKind == JsonValueKind.String &&
@@ -189,16 +215,25 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         [FromQuery(Name = "hub.verify_token")] string? verifyToken,
         [FromQuery(Name = "hub.challenge")] string? challenge,
         IOptions<MetaOptions> metaOptions,
-        ILogger<WhatsAppEndpoints> logger)
+        ILogger<WhatsAppEndpoints> logger,
+        string? accountId = null)
     {
-        if (mode == "subscribe" && verifyToken == metaOptions.Value.VerifyToken && challenge is { Length: > 0 })
+        var valid = false;
+        if (mode == "subscribe" && verifyToken is { Length: > 0 } && challenge is { Length: > 0 })
+        {
+            valid = accountId is not null
+                ? metaOptions.Value.GetVerifyToken(accountId) == verifyToken
+                : metaOptions.Value.FindAccountByVerifyToken(verifyToken) is not null;
+        }
+
+        if (valid)
         {
             logger.LogInformation("Registering webhook callback.");
             return Results.Ok(challenge);
         }
 
-        logger.LogError("Received token {ACTUAL} but expected {EXPECTED}.", verifyToken, metaOptions.Value.VerifyToken);
-        return Results.BadRequest("Received verification token doesn't match the configured one.");
+        logger.LogError("Received token {ACTUAL} but no matching account verify token found.", verifyToken);
+        return Results.BadRequest("Received verification token doesn't match any configured account.");
     }
 
     static async Task<IResult> HandleProcessAsync(

--- a/src/WhatsApp.Functions/AzureFunctionsWebhook.cs
+++ b/src/WhatsApp.Functions/AzureFunctionsWebhook.cs
@@ -40,6 +40,13 @@ class AzureFunctionsWebhook(
 
     [Function("whatsapp_message")]
     public async Task<IActionResult> Message([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp")] HttpRequest req)
+        => await MessageCoreAsync(req, accountId: null);
+
+    [Function("whatsapp_message_account")]
+    public async Task<IActionResult> MessageWithAccount([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "whatsapp/{accountId}")] HttpRequest req, string accountId)
+        => await MessageCoreAsync(req, accountId);
+
+    async Task<IActionResult> MessageCoreAsync(HttpRequest req, string? accountId)
     {
         using var reader = new StreamReader(req.Body, Encoding.UTF8);
         var json = await reader.ReadToEndAsync();
@@ -51,7 +58,7 @@ class AzureFunctionsWebhook(
         // Detect encrypted flow request setup for flows endpoints
         if (JsonSerializer.Deserialize<EncryptedFlowData>(json) is { Data.Length: > 0, IV.Length: > 0, Key.Length: > 0 } encrypted)
         {
-            return await ProcessFlowDataAsync(json, encrypted);
+            return await ProcessFlowDataAsync(json, encrypted, accountId);
         }
 
         if (await WhatsApp.Message.DeserializeAsync(json) is { } message)
@@ -75,14 +82,37 @@ class AzureFunctionsWebhook(
     }
 
 
-    async Task<IActionResult> ProcessFlowDataAsync(string json, EncryptedFlowData encrypted)
+    async Task<IActionResult> ProcessFlowDataAsync(string json, EncryptedFlowData encrypted, string? accountId)
     {
-        if (string.IsNullOrEmpty(metaOptions.Value.PrivateKey))
-            return new StatusCodeResult(421);
+        FlowCryptography? crypto = null;
+        FlowData? data = null;
 
-        var crypto = new FlowCryptography(metaOptions.Value.PrivateKey);
-        if (!crypto.TryDecrypt(encrypted, out var data) || data is null)
-            return new StatusCodeResult(421);
+        if (accountId is not null)
+        {
+            var key = metaOptions.Value.GetPrivateKey(accountId);
+            if (key is null)
+                return new StatusCodeResult(421);
+
+            crypto = new FlowCryptography(key);
+            if (!crypto.TryDecrypt(encrypted, out data) || data is null)
+                return new StatusCodeResult(421);
+        }
+        else
+        {
+            foreach (var key in metaOptions.Value.GetPrivateKeys())
+            {
+                var candidate = new FlowCryptography(key);
+                if (candidate.TryDecrypt(encrypted, out data) && data is not null)
+                {
+                    crypto = candidate;
+                    break;
+                }
+                candidate.Dispose();
+            }
+
+            if (crypto is null || data is null)
+                return new StatusCodeResult(421);
+        }
 
         if (data.Data.TryGetProperty("action", out var action) &&
             action.ValueKind == JsonValueKind.String &&
@@ -148,19 +178,33 @@ class AzureFunctionsWebhook(
 
     [Function("whatsapp_register")]
     public IActionResult Register([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "whatsapp")] HttpRequest req)
+        => RegisterCore(req);
+
+    [Function("whatsapp_register_account")]
+    public IActionResult RegisterWithAccount([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "whatsapp/{accountId}")] HttpRequest req, string accountId)
+        => RegisterCore(req, accountId);
+
+    IActionResult RegisterCore(HttpRequest req, string? accountId = null)
     {
         StringValues token = default;
         if (req.Query.TryGetValue("hub.mode", out var mode) && mode == "subscribe" &&
-            req.Query.TryGetValue("hub.verify_token", out token) && token == metaOptions.Value.VerifyToken &&
+            req.Query.TryGetValue("hub.verify_token", out token) &&
+            token.ToString() is { Length: > 0 } receivedToken &&
             req.Query.TryGetValue("hub.challenge", out var values) &&
             values.ToString() is { } challenge)
         {
-            logger.LogInformation("Registering webhook callback.");
+            var valid = accountId is not null
+                ? metaOptions.Value.GetVerifyToken(accountId) == receivedToken
+                : metaOptions.Value.FindAccountByVerifyToken(receivedToken) is not null;
 
-            return new OkObjectResult(challenge);
+            if (valid)
+            {
+                logger.LogInformation("Registering webhook callback.");
+                return new OkObjectResult(challenge);
+            }
         }
 
-        logger.LogError("Received token {ACTUAL} but expected {EXPECTED}.", token, metaOptions.Value.VerifyToken);
-        return new BadRequestObjectResult("Received verification token doesn't match the configured one.");
+        logger.LogError("Received token {ACTUAL} but no matching account verify token found.", token.ToString());
+        return new BadRequestObjectResult("Received verification token doesn't match any configured account.");
     }
 }

--- a/src/WhatsApp/Flows/FlowCryptography.cs
+++ b/src/WhatsApp/Flows/FlowCryptography.cs
@@ -2,7 +2,6 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Options;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -33,12 +32,6 @@ class FlowCryptography : IDisposable
     const int StandardNonceLength = 12;
 
     readonly RSA rsa;
-
-    /// <summary>Initializes the class with the provided RSA private key from options.</summary>
-    public FlowCryptography(IOptions<MetaOptions> options)
-        : this(Throw.IfNullOrEmpty(options.Value.PrivateKey, "PrivateKey"))
-    {
-    }
 
     /// <summary>Initializes the class with the provided RSA private key in PEM format.</summary>
     public FlowCryptography(string privatePem)

--- a/src/WhatsApp/IWhatsAppClient.cs
+++ b/src/WhatsApp/IWhatsAppClient.cs
@@ -12,7 +12,7 @@ public interface IWhatsAppClient
     /// base address of <c>https://graph.facebook.com/{api_version}/</c> as 
     /// configured for it via <see cref="MetaOptions.ApiVersion"/>.
     /// </summary>
-    /// <param name="numberId">The configured number ID to use for authentication via <see cref="MetaOptions.Numbers"/>.</param>
+    /// <param name="numberId">The configured number ID to use for authentication via <see cref="AccountOptions.Numbers"/>.</param>
     /// <returns>An HTTP client that can safely be disposed after usage.</returns>
     /// <exception cref="ArgumentException">The number <paramref name="numberId"/> is not registered in <see cref="MetaOptions"/>.</exception>
     HttpClient CreateHttp(string numberId);
@@ -20,7 +20,7 @@ public interface IWhatsAppClient
     /// <summary>
     /// Sends a raw payload object that must match the WhatsApp API.
     /// </summary>
-    /// <param name="numberId">The phone identifier to send the message from, which must be configured via <see cref="MetaOptions.Numbers"/>.</param>
+    /// <param name="numberId">The phone identifier to send the message from, which must be configured via <see cref="AccountOptions.Numbers"/>.</param>
     /// <param name="payload">The message payload.</param>>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The message id that was sent/reacted/marked, if any.</returns>

--- a/src/WhatsApp/MetaOptions.cs
+++ b/src/WhatsApp/MetaOptions.cs
@@ -4,6 +4,24 @@ using System.ComponentModel.DataAnnotations;
 namespace Devlooped.WhatsApp;
 
 /// <summary>
+/// Configuration for a WhatsApp Business Account (WABA).
+/// </summary>
+public class AccountOptions
+{
+    /// <summary>Access token for this account, used for both messaging and Flows management API calls.</summary>
+    public required string AccessToken { get; set; }
+
+    /// <summary>Verify token used to register this account's webhook with Meta.</summary>
+    public required string VerifyToken { get; set; }
+
+    /// <summary>Optional RSA private key (PEM) used to decrypt Flows endpoint data exchange requests.</summary>
+    public string? PrivateKey { get; set; }
+
+    /// <summary>List of phone number IDs associated with this account. All share the account token.</summary>
+    public string[] Numbers { get; set; } = [];
+}
+
+/// <summary>
 /// Options for handling communication with WhatsApp for Business from Meta.
 /// </summary>
 public class MetaOptions
@@ -12,18 +30,60 @@ public class MetaOptions
     [DefaultValue("v22.0")]
     public string ApiVersion { get; set; } = "v22.0";
 
-    /// <summary>Optional private key if Flows endpoint data will be processed.</summary>
-    public string? PrivateKey { get; set; }
+    /// <summary>
+    /// WhatsApp Business Accounts indexed by account ID. Each account holds its access token, 
+    /// verify token, an optional RSA private key for Flows, and the list of phone number IDs it owns.
+    /// </summary>
+    [MinLength(1, ErrorMessage = "At least one account must be configured, e.g. Meta:Accounts:12345:AccessToken=asdf")]
+    public IDictionary<string, AccountOptions> Accounts { get; set; } = new Dictionary<string, AccountOptions>();
 
-    /// <summary>Custom string used in the Meta App Dashboard for configuring the webhook.</summary>
-    [Required(ErrorMessage = "Meta:VerifyToken is required to properly register with WhatsApp for Business webhooks.")]
-    public required string VerifyToken { get; set; }
+    /// <summary>
+    /// Returns the access token for the given account ID.
+    /// Returns <see langword="null"/> if no account is found with that ID.
+    /// </summary>
+    public string? GetAccountToken(string accountId)
+        => Accounts.TryGetValue(accountId, out var account) ? account.AccessToken : null;
 
-    /// <summary>Contains pairs of account ID > access token for WhatsApp for Business phone numbers.</summary>
-    [MinLength(1, ErrorMessage = "At least one account ID > access token pair is required, i.e. Meta:Accounts:12345=asdf")]
-    public IDictionary<string, string> Accounts { get; set; } = new Dictionary<string, string>();
+    /// <summary>
+    /// Returns the verify token for the given account ID.
+    /// Returns <see langword="null"/> if no account is found with that ID.
+    /// </summary>
+    public string? GetVerifyToken(string accountId)
+        => Accounts.TryGetValue(accountId, out var account) ? account.VerifyToken : null;
 
-    /// <summary>Contains pairs of number ID > access token for WhatsApp for Business phone numbers.</summary>
-    [MinLength(1, ErrorMessage = "At least one number ID > access token pair is required, i.e. Meta:Numbers:12345=asdf")]
-    public IDictionary<string, string> Numbers { get; set; } = new Dictionary<string, string>();
+    /// <summary>
+    /// Returns the account ID whose <see cref="AccountOptions.VerifyToken"/> matches <paramref name="verifyToken"/>,
+    /// or <see langword="null"/> if no matching account is found.
+    /// </summary>
+    public string? FindAccountByVerifyToken(string verifyToken)
+        => Accounts.FirstOrDefault(a => a.Value.VerifyToken == verifyToken).Key;
+
+    /// <summary>
+    /// Returns the access token for the given phone number ID by finding which account owns it.
+    /// Returns <see langword="null"/> if no account contains <paramref name="numberId"/>.
+    /// </summary>
+    public string? GetToken(string numberId)
+    {
+        foreach (var account in Accounts.Values)
+        {
+            if (Array.IndexOf(account.Numbers, numberId) >= 0)
+                return account.AccessToken;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the RSA private key (PEM) for the given account ID.
+    /// Returns <see langword="null"/> if the account is not found or has no private key configured.
+    /// </summary>
+    public string? GetPrivateKey(string accountId)
+        => Accounts.TryGetValue(accountId, out var account) ? account.PrivateKey : null;
+
+    /// <summary>
+    /// Returns all non-null RSA private keys (PEM) across all accounts, for use when the
+    /// account ID is not known at decryption time.
+    /// </summary>
+    public IEnumerable<string> GetPrivateKeys()
+        => Accounts.Values.Select(a => a.PrivateKey).Where(k => k is not null)!;
 }

--- a/src/WhatsApp/WhatsAppClient.cs
+++ b/src/WhatsApp/WhatsAppClient.cs
@@ -39,7 +39,8 @@ public class WhatsAppClient(IHttpClientFactory httpFactory, IOptions<MetaOptions
     /// <inheritdoc />
     public HttpClient CreateHttp(string numberId)
     {
-        if (!options.Numbers.TryGetValue(numberId, out var token))
+        var token = options.GetToken(numberId) ?? options.GetAccountToken(numberId);
+        if (token is null)
             throw new ArgumentException($"The number '{numberId}' is not registered in the options.", nameof(numberId));
 
         var http = httpFactory.CreateClient("whatsapp");
@@ -53,7 +54,8 @@ public class WhatsAppClient(IHttpClientFactory httpFactory, IOptions<MetaOptions
     /// <inheritdoc />
     public async Task<string?> SendAsync(string numberId, object payload, CancellationToken cancellationToken = default)
     {
-        if (!options.Numbers.TryGetValue(numberId, out var token))
+        var token = options.GetToken(numberId);
+        if (token is null)
         {
             // Try to reply to the debug console
             if (numberId.IsCLI() && Uri.TryCreate(numberId, UriKind.Absolute, out var uri))


### PR DESCRIPTION
This provides a more intuitive configuration and more easily allows multi-tenancy. VerifyToken also moved down to the specific Account.

New config shape:
  Meta:Accounts:{accountId}:Token = <bearer-token>
  Meta:Accounts:{accountId}:PrivateKey = <PEM key>    # optional, for Flows
  Meta:Accounts:{accountId}:Numbers:0 = <numberId>

Removes the flat Meta:Numbers and root Meta:PrivateKey; the token for a given phone number ID is found by iterating account entries.

Flow data decryption strategy:
- If the webhook URL includes /{accountId}, use that account's key
- Otherwise, try all configured account keys until one decrypts

Azure Functions: two [Function] methods per route (optional params unsupported)
ASP.NET Core: single handler with optional accountId parameter on both routes