### PR TITLE
Add extensible Azure Table idempotency with DI support

### DIFF
--- a/src/Tests/IdempotencyTests.cs
+++ b/src/Tests/IdempotencyTests.cs
@@ -6,17 +6,21 @@ namespace Devlooped.WhatsApp;
 
 public class IdempotencyTests
 {
-    [Fact]
-    public async Task CanAddProcessedItem()
+    static HybridCache BuildCache()
     {
-        var client = CloudStorageAccount.DevelopmentStorageAccount.CreateTableServiceClient();
-        var table = client.GetTableClient("WhatsAppWebhook");
-        var collection = new ServiceCollection();
-        collection.AddHybridCache();
-        var cache = collection.BuildServiceProvider().GetRequiredService<HybridCache>();
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
 
-        var idempotent = new Idempotency(client, cache);
-        var pk = nameof(CanAddProcessedItem);
+    [Fact]
+    public async Task TableBackedMode_TracksDurably()
+    {
+        var serviceClient = CloudStorageAccount.DevelopmentStorageAccount.CreateTableServiceClient();
+        var table = serviceClient.GetTableClient("WhatsAppWebhook");
+
+        var idempotent = new Idempotency(BuildCache(), serviceClient);
+        var pk = nameof(TableBackedMode_TracksDurably);
         var rk = Ulid.NewUlid().ToString();
 
         // Initially unprocessed
@@ -41,5 +45,40 @@ public class IdempotencyTests
 
         // The check would now re-read from storage and see it since we restored.
         Assert.True(await idempotent.IsProcessedAsync(pk, rk));
+    }
+
+    [Fact]
+    public async Task CacheOnlyMode_TracksDuplicates()
+    {
+        var idempotent = new Idempotency(BuildCache());
+        var pk = nameof(CacheOnlyMode_TracksDuplicates);
+        var rk = Ulid.NewUlid().ToString();
+
+        Assert.False(await idempotent.IsProcessedAsync(pk, rk));
+
+        var etag = await idempotent.TrySetProcessedAsync(pk, rk);
+
+        Assert.NotNull(etag);
+        Assert.True(await idempotent.IsProcessedAsync(pk, rk));
+
+        // Duplicate claim returns null
+        Assert.Null(await idempotent.TrySetProcessedAsync(pk, rk));
+    }
+
+    [Fact]
+    public async Task CacheOnlyMode_ResetAllowsReprocessing()
+    {
+        var idempotent = new Idempotency(BuildCache());
+        var pk = nameof(CacheOnlyMode_ResetAllowsReprocessing);
+        var rk = Ulid.NewUlid().ToString();
+
+        var etag = await idempotent.TrySetProcessedAsync(pk, rk);
+        Assert.NotNull(etag);
+
+        await idempotent.ResetProcessedAsync(pk, rk, etag.Value);
+
+        // After reset the item can be claimed again
+        Assert.False(await idempotent.IsProcessedAsync(pk, rk));
+        Assert.NotNull(await idempotent.TrySetProcessedAsync(pk, rk));
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.5" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/WhatsApp.Functions/WhatsAppFunctionsBuilderExtensions.cs
+++ b/src/WhatsApp.Functions/WhatsAppFunctionsBuilderExtensions.cs
@@ -246,6 +246,9 @@ public static class WhatsAppFunctionsBuilderExtensions
         // Register the queue processor as the default message processor for Azure Functions
         handlerBuilder.UseQueueProcessor(configure);
 
+        // Use Azure Table Storage for durable idempotency tracking in Azure Functions
+        handlerBuilder.UseIdempotencyStorage("AzureWebJobsStorage");
+
         return handlerBuilder;
     }
 }

--- a/src/WhatsApp/Idempotency.cs
+++ b/src/WhatsApp/Idempotency.cs
@@ -22,7 +22,15 @@ static class IdempotencyExtensions
         => message.Id.StartsWith("wamid.", StringComparison.Ordinal) ? message.Id : Base62.Encode(new BigInteger(MD5.HashData(Encoding.UTF8.GetBytes(payload)), isUnsigned: true, isBigEndian: true));
 }
 
-class Idempotency(TableServiceClient client, HybridCache cache)
+/// <summary>
+/// Tracks which messages have already been processed to avoid duplicate handling.
+/// When a <see cref="TableServiceClient"/> is provided (via
+/// <see cref="IdempotencyStorageExtensions.UseIdempotencyStorage(WhatsAppHandlerBuilder, string)"/>),
+/// idempotency is backed by Azure Table Storage for durability and atomic cross-instance claims.
+/// Otherwise, it operates in cache-only mode using <see cref="HybridCache"/>, suitable for
+/// single-process deployments or when a distributed cache (e.g. Redis) is configured.
+/// </summary>
+class Idempotency(HybridCache cache, TableServiceClient? table = null)
 {
     static readonly HybridCacheEntryOptions options = new()
     {
@@ -30,24 +38,42 @@ class Idempotency(TableServiceClient client, HybridCache cache)
         Expiration = TimeSpan.FromDays(30)
     };
 
-    readonly AsyncLazy<TableClient> table = new(async () =>
+    readonly AsyncLazy<TableClient>? tableClient = table is null ? null : new(async () =>
         {
-            var table = client.GetTableClient("WhatsAppWebhook");
-            await table.CreateIfNotExistsAsync();
-            return table;
+            var t = table.GetTableClient("WhatsAppWebhook");
+            await t.CreateIfNotExistsAsync();
+            return t;
         });
 
     public ValueTask<bool> IsProcessedAsync(string partitionKey, string rowKey, CancellationToken token = default)
-        => cache.GetOrCreateAsync(Key(partitionKey, rowKey),
-            async key => await (await table).GetEntityIfExistsAsync<TableEntity>(partitionKey, rowKey, cancellationToken: token) is { HasValue: true },
+    {
+        var key = Key(partitionKey, rowKey);
+        if (tableClient is null)
+            return cache.GetOrCreateAsync(key, _ => ValueTask.FromResult(false), options, cancellationToken: token);
+
+        return cache.GetOrCreateAsync(key,
+            async _ => await (await tableClient).GetEntityIfExistsAsync<TableEntity>(partitionKey, rowKey, cancellationToken: token) is { HasValue: true },
             options, cancellationToken: token);
+    }
 
     public async ValueTask<ETag?> TrySetProcessedAsync(string partitionKey, string rowKey, CancellationToken token = default)
     {
         var key = Key(partitionKey, rowKey);
+
+        if (tableClient is null)
+        {
+            // Cache-only mode: best-effort claim. Suitable for single-process or distributed-cache scenarios.
+            // A small TOCTOU race exists in multi-instance deployments without a distributed cache.
+            if (await IsProcessedAsync(partitionKey, rowKey, token))
+                return null;
+
+            await cache.SetAsync(key, true, options, cancellationToken: token);
+            return ETag.All;
+        }
+
         try
         {
-            var entity = await (await table).AddEntityAsync(new TableEntity(partitionKey, rowKey), token);
+            var entity = await (await tableClient).AddEntityAsync(new TableEntity(partitionKey, rowKey), token);
             await cache.SetAsync(key, true, options, cancellationToken: token);
             return entity.Headers.ETag ?? ETag.All;
         }
@@ -62,7 +88,14 @@ class Idempotency(TableServiceClient client, HybridCache cache)
     {
         // If actual processing of a previously marked item failed, we want to return its unprocessed state
         var key = Key(partitionKey, rowKey);
-        await (await table).DeleteEntityAsync(partitionKey, rowKey, etag, token);
+
+        if (tableClient is null)
+        {
+            await cache.RemoveAsync(key, token);
+            return;
+        }
+
+        await (await tableClient).DeleteEntityAsync(partitionKey, rowKey, etag, token);
         await cache.RemoveAsync(key, token);
     }
 

--- a/src/WhatsApp/IdempotencyStorageExtensions.cs
+++ b/src/WhatsApp/IdempotencyStorageExtensions.cs
@@ -1,0 +1,132 @@
+using Azure.Data.Tables;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Devlooped.WhatsApp;
+
+/// <summary>
+/// Extensions for configuring durable Azure Table Storage-backed idempotency tracking.
+/// </summary>
+public static class IdempotencyStorageExtensions
+{
+    /// <summary>
+    /// The keyed service key used to register the <see cref="TableServiceClient"/> dedicated to
+    /// idempotency storage, so it does not conflict with any app-wide <see cref="TableServiceClient"/>.
+    /// </summary>
+    public const string ServiceKey = "WhatsAppIdempotencyStorage";
+
+    /// <summary>
+    /// Configures Azure Table Storage for durable, atomic idempotency tracking using an already
+    /// registered (unkeyed) <see cref="TableServiceClient"/> from the dependency injection container.
+    /// </summary>
+    /// <param name="builder">The handler pipeline builder.</param>
+    /// <remarks>
+    /// Use this overload when a <see cref="TableServiceClient"/> is already registered in the
+    /// service collection and you want to reuse it for idempotency storage.
+    /// <para>
+    /// Without calling any <c>UseIdempotencyStorage</c> overload, idempotency operates in 
+    /// cache-only mode using <see cref="Microsoft.Extensions.Caching.Hybrid.HybridCache"/>,
+    /// which is suitable for single-process deployments or when a distributed cache (e.g. Redis)
+    /// is configured.
+    /// </para>
+    /// <para>
+    /// Calling this method multiple times replaces the previous registration — the last call wins.
+    /// </para>
+    /// </remarks>
+    public static WhatsAppHandlerBuilder UseIdempotencyStorage(this WhatsAppHandlerBuilder builder)
+    {
+        _ = Throw.IfNull(builder);
+
+        ReplaceKeyedTableServiceClient(builder.Services);
+        builder.Services.AddKeyedSingleton<TableServiceClient>(ServiceKey,
+            (sp, _) => sp.GetRequiredService<TableServiceClient>());
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures Azure Table Storage for durable, atomic idempotency tracking, in addition to
+    /// the in-memory and distributed cache layers provided by default.
+    /// </summary>
+    /// <param name="builder">The handler pipeline builder.</param>
+    /// <param name="connectionStringOrKey">
+    /// A configuration key (resolved via <see cref="IConfiguration"/>) or a literal Azure Storage 
+    /// connection string. Configuration lookup is attempted first; if no matching key is found, 
+    /// the value is used as a literal connection string.
+    /// </param>
+    /// <remarks>
+    /// Without calling any <c>UseIdempotencyStorage</c> overload, idempotency operates in 
+    /// cache-only mode using <see cref="Microsoft.Extensions.Caching.Hybrid.HybridCache"/>,
+    /// which is suitable for single-process deployments or when a distributed cache (e.g. Redis) 
+    /// is configured. Table Storage adds durability across restarts and atomic cross-instance 
+    /// claim semantics.
+    /// <para>
+    /// Calling this method multiple times replaces the previous registration — the last call wins.
+    /// </para>
+    /// </remarks>
+    public static WhatsAppHandlerBuilder UseIdempotencyStorage(this WhatsAppHandlerBuilder builder, string connectionStringOrKey)
+    {
+        _ = Throw.IfNull(builder);
+        _ = Throw.IfNull(connectionStringOrKey);
+
+        ReplaceKeyedTableServiceClient(builder.Services);
+
+        builder.Services.AddKeyedSingleton<TableServiceClient>(ServiceKey, (sp, _) =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var connectionString = config[connectionStringOrKey] ?? connectionStringOrKey;
+            return new TableServiceClient(connectionString, new TableClientOptions
+            {
+#if DEBUG
+                Diagnostics =
+                {
+                    IsLoggingEnabled = true,
+                    IsLoggingContentEnabled = true,
+                },
+#endif
+            });
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures Azure Table Storage for durable, atomic idempotency tracking using a pre-configured
+    /// <see cref="TableServiceClient"/> instance.
+    /// </summary>
+    /// <param name="builder">The handler pipeline builder.</param>
+    /// <param name="client">The <see cref="TableServiceClient"/> to use for idempotency storage.</param>
+    /// <remarks>
+    /// The client is registered as a keyed service under <see cref="ServiceKey"/> and does not
+    /// affect any app-wide (unkeyed) <see cref="TableServiceClient"/> registrations.
+    /// <para>
+    /// Without calling any <c>UseIdempotencyStorage</c> overload, idempotency operates in 
+    /// cache-only mode using <see cref="Microsoft.Extensions.Caching.Hybrid.HybridCache"/>,
+    /// which is suitable for single-process deployments or when a distributed cache (e.g. Redis) 
+    /// is configured.
+    /// </para>
+    /// <para>
+    /// Calling this method multiple times replaces the previous registration — the last call wins.
+    /// </para>
+    /// </remarks>
+    public static WhatsAppHandlerBuilder UseIdempotencyStorage(this WhatsAppHandlerBuilder builder, TableServiceClient client)
+    {
+        _ = Throw.IfNull(builder);
+        _ = Throw.IfNull(client);
+
+        ReplaceKeyedTableServiceClient(builder.Services);
+        builder.Services.AddKeyedSingleton<TableServiceClient>(ServiceKey, client);
+
+        return builder;
+    }
+
+    static void ReplaceKeyedTableServiceClient(IServiceCollection services)
+    {
+        var existing = services.FirstOrDefault(x =>
+            x.IsKeyedService &&
+            x.ServiceType == typeof(TableServiceClient) &&
+            ServiceKey.Equals(x.ServiceKey));
+        if (existing != null)
+            services.Remove(existing);
+    }
+}

--- a/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
+++ b/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Azure.Data.Tables;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -229,26 +230,12 @@ static class WhatsAppServiceCollectionExtensions
     {
         services.AddHttpClient("whatsapp").AddStandardResilienceHandler();
         services.AddHybridCache();
-        services.AddSingleton<Idempotency>();
+        services.AddSingleton<Idempotency>(sp => new Idempotency(
+            sp.GetRequiredService<HybridCache>(),
+            sp.GetKeyedService<TableServiceClient>(IdempotencyStorageExtensions.ServiceKey)));
 
         if (services.FirstOrDefault(x => x.ServiceType == typeof(IWhatsAppClient)) == null)
             services.Add(new ServiceDescriptor(typeof(IWhatsAppClient), typeof(WhatsAppClient), lifetime));
-
-        if (services.FirstOrDefault(x => x.ServiceType == typeof(TableServiceClient)) == null)
-        {
-            services.AddSingleton(services => new TableServiceClient(
-                services.GetRequiredService<IConfiguration>()["AzureWebJobsStorage"]!,
-                new TableClientOptions
-                {
-#if DEBUG
-                    Diagnostics =
-                    {
-                        IsLoggingEnabled = true,
-                        IsLoggingContentEnabled = true,
-                    },
-#endif
-                }));
-        }
 
         if (services.FirstOrDefault(x => x.ServiceType == typeof(CloudStorageAccount)) == null)
         {


### PR DESCRIPTION
Introduce IdempotencyStorageExtensions for flexible Azure Table Storage-backed idempotency tracking, supporting both cache-only and durable modes via keyed DI registration. Refactor Idempotency to handle both scenarios and update service registration patterns. Enhance tests to cover both modes and improve code style for consistency.