### PR TITLE
Update MetaOptions Numbers binding and EchoHandler logic

### DIFF
--- a/src/SampleApp/SampleWeb/Program.cs
+++ b/src/SampleApp/SampleWeb/Program.cs
@@ -71,12 +71,9 @@ class EchoHandler : IWhatsAppHandler
         IEnumerable<IMessage> messages,
         [EnumeratorCancellation] CancellationToken cancellation = default)
     {
-        foreach (var message in messages)
+        if (messages.OfType<ContentMessage>().LastOrDefault() is { } message)
         {
-            if (message is ContentMessage content)
-            {
-                yield return content.Reply($"Echo: {content.Content}");
-            }
+            yield return message.Reply($"Echo: {message.Content}");
         }
 
         await Task.CompletedTask;

--- a/src/Tests/MetaOptionsTests.cs
+++ b/src/Tests/MetaOptionsTests.cs
@@ -33,6 +33,82 @@ public class MetaOptionsTests
     }
 
     [Fact]
+    public void SingleStringNumberBindsAsArray()
+    {
+        var collection = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>()
+            {
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers", "9876543210" }
+            }).Build());
+
+        collection.AddOptions<MetaOptions>()
+            .BindConfiguration("Meta")
+            .PostConfigure<IConfiguration>((options, config) =>
+            {
+                foreach (var (accountId, account) in options.Accounts)
+                {
+                    if (account.Numbers.Length == 0)
+                    {
+                        var value = config[$"Meta:Accounts:{accountId}:Numbers"];
+                        if (!string.IsNullOrEmpty(value))
+                            account.Numbers = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    }
+                }
+            })
+            .ValidateDataAnnotations();
+
+        var options = collection
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<MetaOptions>>().Value;
+
+        Assert.NotNull(options);
+        Assert.Single(options.Accounts["1234567890"].Numbers);
+        Assert.Equal("9876543210", options.Accounts["1234567890"].Numbers[0]);
+        Assert.Equal("test-access-token", options.GetToken("9876543210"));
+    }
+
+    [Fact]
+    public void CommaSeparatedNumbersStringBindsAsArray()
+    {
+        var collection = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>()
+            {
+                { "Meta:Accounts:1234567890:VerifyToken", "test-challenge" },
+                { "Meta:Accounts:1234567890:AccessToken", "test-access-token" },
+                { "Meta:Accounts:1234567890:Numbers", "9876543210, 1111111111" }
+            }).Build());
+
+        collection.AddOptions<MetaOptions>()
+            .BindConfiguration("Meta")
+            .PostConfigure<IConfiguration>((options, config) =>
+            {
+                foreach (var (accountId, account) in options.Accounts)
+                {
+                    if (account.Numbers.Length == 0)
+                    {
+                        var value = config[$"Meta:Accounts:{accountId}:Numbers"];
+                        if (!string.IsNullOrEmpty(value))
+                            account.Numbers = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    }
+                }
+            })
+            .ValidateDataAnnotations();
+
+        var options = collection
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<MetaOptions>>().Value;
+
+        Assert.NotNull(options);
+        Assert.Equal(2, options.Accounts["1234567890"].Numbers.Length);
+        Assert.Equal("test-access-token", options.GetToken("9876543210"));
+        Assert.Equal("test-access-token", options.GetToken("1111111111"));
+    }
+
+    [Fact]
     public void FindAccountByVerifyTokenReturnsNullForUnknownToken()
     {
         var options = new MetaOptions

--- a/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
+++ b/src/WhatsApp/WhatsAppServiceCollectionExtensions.cs
@@ -245,6 +245,20 @@ static class WhatsAppServiceCollectionExtensions
 
         builder.Services.AddOptionsWithValidateOnStart<MetaOptions>()
             .BindConfiguration("Meta")
+            .PostConfigure<IConfiguration>((options, config) =>
+            {
+                // The configuration system can't bind a scalar string to string[].
+                // Support "Numbers": "id" or "Numbers": "id1,id2" as alternatives to "Numbers:0": "id".
+                foreach (var (accountId, account) in options.Accounts)
+                {
+                    if (account.Numbers.Length == 0)
+                    {
+                        var value = config[$"Meta:Accounts:{accountId}:Numbers"];
+                        if (!string.IsNullOrEmpty(value))
+                            account.Numbers = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    }
+                }
+            })
             .ValidateDataAnnotations();
 
         var options = services.AddOptions<WhatsAppOptions>()


### PR DESCRIPTION
- Add tests for single/comma-separated Numbers string binding.
- PostConfigure MetaOptions to support scalar and CSV Numbers config.