### PR TITLE
Add connectivity ping to CLI with backend version header

### DIFF
--- a/src/Console/Interactive.cs
+++ b/src/Console/Interactive.cs
@@ -29,7 +29,7 @@ partial class Interactive(IConfiguration configuration, IHttpClientFactory httpF
     Timer personTimer = new() { AutoReset = false };
     CancellationTokenSource? typingCancellation = null;
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(service))
         {
@@ -37,9 +37,44 @@ partial class Interactive(IConfiguration configuration, IHttpClientFactory httpF
             Config.Build(ConfigLevel.Global)
                 .SetString("whatsapp", "endpoint", service);
         }
+
+        // Connectivity check: HEAD the endpoint and show version if available.
+        while (true)
+        {
+            string? version = null;
+            var connected = false;
+            await AnsiConsole.Status().StartAsync($"Connecting to {service}...", async _ =>
+            {
+                try
+                {
+                    using var http = httpFactory.CreateClient("whatsapp");
+                    http.Timeout = TimeSpan.FromSeconds(10);
+                    using var response = await http.SendAsync(new HttpRequestMessage(HttpMethod.Head, service), cancellationToken);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        response.Headers.TryGetValues("X-WhatsApp-Version", out var values);
+                        version = values?.FirstOrDefault();
+                        connected = true;
+                    }
+                }
+                catch { }
+            });
+
+            if (connected)
+            {
+                var versionSuffix = version is { Length: > 0 } ? $" [grey](v{version})[/]" : "";
+                AnsiConsole.MarkupLine($":check_mark_button: [green]Connected[/]{versionSuffix}");
+                break;
+            }
+
+            AnsiConsole.MarkupLine($"[red]Could not connect to[/] {service}");
+            service = AnsiConsole.Ask("Enter WhatsApp functions endpoint", service);
+            Config.Build(ConfigLevel.Global)
+                .SetString("whatsapp", "endpoint", service);
+        }
+
         if (format == null)
         {
-            var choices = Enum.GetValues<MessageType>();
             format = AnsiConsole.Prompt(
                 new SelectionPrompt<OutputFormat>()
                     .Title("Select output format")
@@ -74,8 +109,6 @@ partial class Interactive(IConfiguration configuration, IHttpClientFactory httpF
 
         _ = Task.Run(ResponseListener, cancellationToken);
         _ = Task.Run(InputListener, cancellationToken);
-
-        return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/WhatsApp.AspNetCore/WhatsAppEndpointRouteBuilderExtensions.cs
+++ b/src/WhatsApp.AspNetCore/WhatsAppEndpointRouteBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class WhatsAppEndpointRouteBuilderExtensions
     /// <item><description>GET /whatsapp - Webhook verification endpoint</description></item>
     /// <item><description>POST /whatsapp/process - Direct message processing endpoint (requires X-WHATSAPP-SECRET header)</description></item>
     /// <item><description>POST /whatsapp/eventgrid - Azure Event Grid event processing endpoint</description></item>
-    /// <item><description>POST/GET /whatsapp/cli - Development console endpoint</description></item>
+    /// <item><description>POST/GET/HEAD /whatsapp/cli - Development console endpoint</description></item>
     /// </list>
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
@@ -60,8 +60,8 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         // POST /whatsapp/eventgrid - Azure Event Grid event processing endpoint
         endpoints.MapPost("/whatsapp/eventgrid", HandleEventGridAsync);
 
-        // POST/GET /whatsapp/cli - Development console endpoint
-        endpoints.MapMethods("/whatsapp/cli", ["POST", "GET"], HandleConsoleAsync);
+        // POST/GET/HEAD /whatsapp/cli - Development console endpoint
+        endpoints.MapMethods("/whatsapp/cli", ["POST", "GET", "HEAD"], HandleConsoleAsync);
 
         // Legacy console endpoint redirect
         endpoints.MapMethods("/whatsappcli", ["POST", "GET"], (HttpRequest request) =>
@@ -289,6 +289,12 @@ public static class WhatsAppEndpointRouteBuilderExtensions
         // This endpoint is only available in development environments, since it allows sending messages from the debug console.
         if (environment.IsProduction())
             return Results.Unauthorized();
+
+        if (request.Method.Equals("HEAD", StringComparison.OrdinalIgnoreCase))
+        {
+            request.HttpContext.Response.Headers["X-WhatsApp-Version"] = ThisAssembly.Info.InformationalVersion;
+            return Results.Ok();
+        }
 
         if (request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/WhatsApp.Functions/AzureFunctionsConsole.cs
+++ b/src/WhatsApp.Functions/AzureFunctionsConsole.cs
@@ -29,11 +29,17 @@ class AzureFunctionsConsole(
         => new RedirectResult(req.Path.Value.Replace("whatsappcli", "whatsapp/cli"), true, true);
 
     [Function("whatsapp_console")]
-    public async Task<IActionResult> MessageConsole([HttpTrigger(AuthorizationLevel.Anonymous, ["post", "get"], Route = "whatsapp/cli")] HttpRequest req)
+    public async Task<IActionResult> MessageConsole([HttpTrigger(AuthorizationLevel.Anonymous, ["post", "get", "head"], Route = "whatsapp/cli")] HttpRequest req)
     {
         // This endpoint is only available in development environments, since it allows sending messages from the debug console.
         if (environment.IsProduction())
             return new UnauthorizedResult();
+
+        if (req.Method.Equals("HEAD", StringComparison.OrdinalIgnoreCase))
+        {
+            req.HttpContext.Response.Headers["X-WhatsApp-Version"] = ThisAssembly.Info.InformationalVersion;
+            return new OkResult();
+        }
 
         if (req.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
- HEAD verb added to /whatsapp/cli endpoint; returns X-WhatsApp-Version header
- CLI pings on startup, shows spinner + green check with version on success
- On failure, re-prompts for URL and persists it before retrying