### PR TITLE
Auto-populate User.Number from Id when no phone number is provided

### DIFF
--- a/src/Tests/BsuidTests.cs
+++ b/src/Tests/BsuidTests.cs
@@ -61,6 +61,41 @@ public class BsuidTests
     }
 
     [Fact]
+    public void PhoneOnlyUser_NoNumberArg_NumberEqualsNormalizedId()
+    {
+        // When number is omitted and Id is a phone, Number is auto-set from Id.
+        var user = new User("kzu", "5491122334455");
+        Assert.False(user.IsBSUID);
+        Assert.Equal("541122334455", user.Number);
+    }
+
+    [Fact]
+    public void PhoneOnlyUser_ExplicitNullNumber_NumberEqualsNormalizedId()
+    {
+        // Explicit null behaves the same as omitting the number argument.
+        var user = new User("kzu", "5491122334455", null);
+        Assert.False(user.IsBSUID);
+        Assert.Equal("541122334455", user.Number);
+    }
+
+    [Fact]
+    public void PhoneOnlyUser_LeadingPlus_NumberStripsPlus()
+    {
+        var user = new User("kzu", "+12025551234");
+        Assert.False(user.IsBSUID);
+        Assert.Equal("12025551234", user.Number);
+    }
+
+    [Fact]
+    public void BsuidUser_NoNumberArg_NumberRemainsNull()
+    {
+        // BSUID users with no phone number keep Number = null even when number is omitted.
+        var user = new User("kzu", "AR.aBc123XyZ");
+        Assert.True(user.IsBSUID);
+        Assert.Null(user.Number);
+    }
+
+    [Fact]
     public void RecipientType_UsesIndividualForPhone()
         => Assert.Equal("individual", WhatsAppClientExtensions.RecipientType("5491122334455"));
 

--- a/src/WhatsApp/User.cs
+++ b/src/WhatsApp/User.cs
@@ -35,6 +35,8 @@ public record User
         Name = name;
         Id = id;
         Number = number?.NormalizeNumber();
+        if (Number is null && !IsBSUID)
+            Number = Id.NormalizeNumber();
     }
 
     /// <summary>


### PR DESCRIPTION
When constructing a User with a phone-number Id and no explicit number, Number is now automatically set to the normalized Id value. BSUID users are unaffected (Number stays null).

Adds four new tests verifying the new behavior:
- Phone Id with no number arg populates Number
- Explicit null number behaves the same as omitting it
- Leading + in Id is stripped when auto-populating Number
- BSUID users with no number keep Number as null