### PR TITLE
Fix BSUID send addressing: use recipient field, not invalid recipient_type

### DIFF
--- a/src/Tests/BsuidTests.cs
+++ b/src/Tests/BsuidTests.cs
@@ -96,10 +96,31 @@ public class BsuidTests
     }
 
     [Fact]
-    public void RecipientType_UsesIndividualForPhone()
-        => Assert.Equal("individual", WhatsAppClientExtensions.RecipientType("5491122334455"));
+    public void PhoneId_GoesInToField_NotRecipient()
+    {
+        Assert.Equal("5491122334455", WhatsAppClientExtensions.ToField("5491122334455"));
+        Assert.Null(WhatsAppClientExtensions.RecipientField("5491122334455"));
+    }
 
     [Fact]
-    public void RecipientType_UsesBusinessScopedForBsuid()
-        => Assert.Equal("business_scoped_user_id", WhatsAppClientExtensions.RecipientType("AR.aBc123XyZ"));
+    public void Bsuid_GoesInRecipientField_NotTo()
+    {
+        // Meta keeps recipient_type="individual" and puts the BSUID in the newer
+        // "recipient" field — not recipient_type="business_scoped_user_id" / to.
+        Assert.Null(WhatsAppClientExtensions.ToField("AR.aBc123XyZ"));
+        Assert.Equal("AR.aBc123XyZ", WhatsAppClientExtensions.RecipientField("AR.aBc123XyZ"));
+    }
+
+    [Fact]
+    public void PreferAddress_UsesPhoneWhenAvailable()
+    {
+        var mixed = new User("kzu", "AR.aBc123XyZ", "5491122334455");
+        Assert.Equal("541122334455", WhatsAppClientExtensions.PreferAddress(mixed));
+
+        var privacy = new User("kzu", "AR.aBc123XyZ", null);
+        Assert.Equal("AR.aBc123XyZ", WhatsAppClientExtensions.PreferAddress(privacy));
+
+        var phone = new User("kzu", "5491122334455");
+        Assert.Equal("541122334455", WhatsAppClientExtensions.PreferAddress(phone));
+    }
 }

--- a/src/Tests/MetaOptionsTests.cs
+++ b/src/Tests/MetaOptionsTests.cs
@@ -27,7 +27,7 @@ public class MetaOptionsTests
         Assert.NotNull(options);
         Assert.Equal("test-challenge", options.GetVerifyToken("1234567890"));
         Assert.Equal("test-access-token", options.GetToken("1234567890"));
-        Assert.Equal("v22.0", options.ApiVersion);
+        Assert.Equal("v25.0", options.ApiVersion);
     }
 
     [Fact]

--- a/src/WhatsApp/CallToFlowResponse.cs
+++ b/src/WhatsApp/CallToFlowResponse.cs
@@ -74,8 +74,9 @@ public record CallToFlowResponse : Response
         var id = await client.SendAsync(ServiceId, new
         {
             messaging_product = "whatsapp",
-            recipient_type = User.IsBusinessScopedUserId(UserId) ? "business_scoped_user_id" : "individual",
-            to = UserId,
+            recipient_type = "individual",
+            to = WhatsAppClientExtensions.ToField(UserId),
+            recipient = WhatsAppClientExtensions.RecipientField(UserId),
             type = "interactive",
             interactive = new
             {

--- a/src/WhatsApp/MessageExtensions.cs
+++ b/src/WhatsApp/MessageExtensions.cs
@@ -58,14 +58,16 @@ public static partial class MessageExtensions
         /// </summary>
         public ReactionResponse React(string emoji)
             => message is UserMessage user
-                ? new(user.Service, message.UserId, message.Id, emoji)
+                ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), message.Id, emoji)
                 : new(message.ServiceId, message.UserId, message.Id, emoji);
 
         /// <summary>
         /// Creates a simple template response for the message.
         /// </summary>
         public TemplateResponse Template(string name, string language)
-            => new(message.ServiceId, message.UserId, message.Id, name, language);
+            => message is UserMessage user
+                ? new(message.ServiceId, WhatsAppClientExtensions.PreferAddress(user.User), message.Id, name, language)
+                : new(message.ServiceId, message.UserId, message.Id, name, language);
 
         /// <summary>
         /// Creates a complex template response for the message.
@@ -75,7 +77,9 @@ public static partial class MessageExtensions
         /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#template-object"/>
         /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#components-object"/>
         public TemplateResponse Template(MessageTemplate template)
-            => new(message.ServiceId, message.UserId, message.Id, template);
+            => message is UserMessage user
+                ? new(message.ServiceId, WhatsAppClientExtensions.PreferAddress(user.User), message.Id, template)
+                : new(message.ServiceId, message.UserId, message.Id, template);
 
         /// <summary>
         /// Sends an interactive call to action response to the user message.
@@ -85,7 +89,7 @@ public static partial class MessageExtensions
         /// <param name="url">The URL to navigate to when the action button is clicked.</param>
         public CallToActionResponse CallToAction(string text, string action, Uri uri)
             => message is UserMessage user
-            ? new(user.Service, message.UserId, text, action, uri.AbsoluteUri)
+            ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), text, action, uri.AbsoluteUri)
             : new(message.ServiceId, message.UserId, text, action, uri.AbsoluteUri);
 
         /// <summary>
@@ -95,7 +99,9 @@ public static partial class MessageExtensions
         /// <param name="action">The action button text.</param>
         /// <param name="flowName">The name of the flow to initiate.</param>
         public CallToFlowResponse CallToAction(string text, string action, string flowName, bool draft = false)
-            => new(message.ServiceId, message.UserId, text, action, new FlowParameters(flowName) { Mode = draft ? FlowMode.Draft : FlowMode.Published });
+            => message is UserMessage user
+                ? new(message.ServiceId, WhatsAppClientExtensions.PreferAddress(user.User), text, action, new FlowParameters(flowName) { Mode = draft ? FlowMode.Draft : FlowMode.Published })
+                : new(message.ServiceId, message.UserId, text, action, new FlowParameters(flowName) { Mode = draft ? FlowMode.Draft : FlowMode.Published });
 
         /// <summary>
         /// Sends an interactive call to initiate a flow response to the user message.
@@ -104,7 +110,9 @@ public static partial class MessageExtensions
         /// <param name="action">The action button text.</param>
         /// <param name="flowId">The id of the flow to initiate.</param>
         public CallToFlowResponse CallToAction(string text, string action, long flowId, bool draft = false)
-            => new(message.ServiceId, message.UserId, text, action, new FlowParameters(flowId) { Mode = draft ? FlowMode.Draft : FlowMode.Published });
+            => message is UserMessage user
+                ? new(message.ServiceId, WhatsAppClientExtensions.PreferAddress(user.User), text, action, new FlowParameters(flowId) { Mode = draft ? FlowMode.Draft : FlowMode.Published })
+                : new(message.ServiceId, message.UserId, text, action, new FlowParameters(flowId) { Mode = draft ? FlowMode.Draft : FlowMode.Published });
 
         /// <summary>
         /// Sends an interactive call to initiate a flow response to the user message.
@@ -113,14 +121,16 @@ public static partial class MessageExtensions
         /// <param name="action">The action button text.</param>
         /// <param name="flowId">The id of the flow to initiate.</param>
         public CallToFlowResponse CallToAction(string text, string action, FlowParameters flow)
-            => new(message.ServiceId, message.UserId, text, action, flow);
+            => message is UserMessage user
+                ? new(message.ServiceId, WhatsAppClientExtensions.PreferAddress(user.User), text, action, flow)
+                : new(message.ServiceId, message.UserId, text, action, flow);
 
         /// <summary>
         /// Creates a text reply for the message.
         /// </summary>
         public TextResponse Reply(string text)
             => message is UserMessage user
-            ? new(user.Service, message.UserId, message.Id, text)
+            ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), message.Id, text)
             : new(message.ServiceId, message.UserId, message.Id, text);
 
         /// <summary>
@@ -128,7 +138,7 @@ public static partial class MessageExtensions
         /// </summary>
         public TextResponse Reply(string text, Button button1, Button? button2 = default, Button? button3 = default)
             => message is UserMessage user
-                ? new(user.Service, message.UserId, message.Id, text, button1, button2, button3)
+                ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), message.Id, text, button1, button2, button3)
                 : new(message.ServiceId, message.UserId, message.Id, text, button1, button2, button3);
 
         /// <summary>
@@ -136,7 +146,7 @@ public static partial class MessageExtensions
         /// </summary>
         public TextResponse Send(string text)
             => message is UserMessage user
-            ? new(user.Service, message.UserId, null, text)
+            ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), null, text)
             : new(message.ServiceId, message.UserId, null, text);
 
         /// <summary>
@@ -144,7 +154,7 @@ public static partial class MessageExtensions
         /// </summary>
         public TextResponse Send(string text, Button button1, Button? button2 = default, Button? button3 = default)
             => message is UserMessage user
-                ? new(user.Service, message.UserId, null, text, button1, button2, button3)
+                ? new(user.Service, WhatsAppClientExtensions.PreferAddress(user.User), null, text, button1, button2, button3)
                 : new(message.ServiceId, message.UserId, null, text, button1, button2, button3);
     }
 
@@ -154,7 +164,7 @@ public static partial class MessageExtensions
         /// Sends a typing indicator status to signal that there is an ongoing response to the user message.
         /// </summary>
         public TypingResponse Typing()
-            => new(message.Service, message.User.Id, message.Id);
+            => new(message.Service, WhatsAppClientExtensions.PreferAddress(message.User), message.Id);
     }
 
     extension<T>(T message) where T : IMessage

--- a/src/WhatsApp/MetaOptions.cs
+++ b/src/WhatsApp/MetaOptions.cs
@@ -26,9 +26,9 @@ public class AccountOptions
 /// </summary>
 public class MetaOptions
 {
-    /// <summary>API version for messages, defaults to v22.0.</summary>
-    [DefaultValue("v22.0")]
-    public string ApiVersion { get; set; } = "v22.0";
+    /// <summary>API version for messages, defaults to v25.0.</summary>
+    [DefaultValue("v25.0")]
+    public string ApiVersion { get; set; } = "v25.0";
 
     /// <summary>
     /// WhatsApp Business Accounts indexed by account ID. Each account holds its access token, 

--- a/src/WhatsApp/WhatsAppClientExtensions.cs
+++ b/src/WhatsApp/WhatsAppClientExtensions.cs
@@ -9,12 +9,33 @@ namespace Devlooped.WhatsApp;
 public static partial class WhatsAppClientExtensions
 {
     /// <summary>
-    /// Selects the WhatsApp Cloud API <c>recipient_type</c> value based on the shape of the
-    /// given user identifier: <c>"business_scoped_user_id"</c> for BSUIDs, <c>"individual"</c>
-    /// for phone numbers.
+    /// Phone number for the Cloud API <c>to</c> field, or <see langword="null"/> when
+    /// <paramref name="userId"/> is a BSUID (serialized away via WhenWritingNull).
     /// </summary>
-    internal static string RecipientType(string userId)
-        => User.IsBusinessScopedUserId(userId) ? "business_scoped_user_id" : "individual";
+    /// <remarks>
+    /// BSUIDs must not be placed in <c>to</c>. Use <see cref="RecipientField"/> instead.
+    /// <c>recipient_type</c> remains <c>"individual"</c> for 1:1 messages — Meta does not
+    /// accept <c>"business_scoped_user_id"</c> as a <c>recipient_type</c> enum value
+    /// (allowed: <c>individual</c>, <c>group</c>, or null).
+    /// </remarks>
+    /// <seealso href="https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids/"/>
+    internal static string? ToField(string userId)
+        => User.IsBusinessScopedUserId(userId) ? null : userId;
+
+    /// <summary>
+    /// BSUID for the Cloud API <c>recipient</c> field, or <see langword="null"/> when
+    /// <paramref name="userId"/> is a phone number (serialized away via WhenWritingNull).
+    /// </summary>
+    /// <seealso href="https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids/"/>
+    internal static string? RecipientField(string userId)
+        => User.IsBusinessScopedUserId(userId) ? userId : null;
+
+    /// <summary>
+    /// Prefers a known phone number for sending when available, otherwise the user id
+    /// (phone or BSUID). Meta recommends phone when known so webhooks keep including it.
+    /// </summary>
+    internal static string PreferAddress(User user)
+        => user.Number ?? user.Id;
 
     /// <summary>
     /// Creates an authenticated HTTP client for the given service number.
@@ -63,7 +84,7 @@ public static partial class WhatsAppClientExtensions
     /// <param name="cancellation">The cancellation token.</param>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#reaction-object"/>
     public static Task ReactAsync(this IWhatsAppClient client, UserMessage message, string emoji, CancellationToken cancellation = default)
-        => ReactAsync(client, message.Service.Id, message.User.Id, message.Id, emoji, cancellation);
+        => ReactAsync(client, message.Service.Id, PreferAddress(message.User), message.Id, emoji, cancellation);
 
     /// <summary>
     /// Reacts to a message.
@@ -79,8 +100,9 @@ public static partial class WhatsAppClientExtensions
         => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "reaction",
             reaction = new
             {
@@ -104,7 +126,9 @@ public static partial class WhatsAppClientExtensions
         => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "template",
             template
         }, cancellation);
@@ -125,8 +149,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "text",
             context = new
             {
@@ -155,8 +180,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             context = new
             {
@@ -197,8 +223,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             context = new
             {
@@ -241,8 +268,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             context = new
             {
@@ -277,7 +305,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply, CancellationToken cancellation = default)
-        => ReplyAsync(client, message.Service.Id, message.User.Id, message.Id, reply, cancellation);
+        => ReplyAsync(client, message.Service.Id, PreferAddress(message.User), message.Id, reply, cancellation);
 
     /// <summary>
     /// Replies to a user message with an additional interactive button.
@@ -290,7 +318,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply, Button button, CancellationToken cancellation = default)
-        => ReplyAsync(client, message.Service.Id, message.User.Id, message.Id, reply, button, cancellation);
+        => ReplyAsync(client, message.Service.Id, PreferAddress(message.User), message.Id, reply, button, cancellation);
 
     /// <summary>
     /// Replies to a user message with additional interactive buttons.
@@ -304,7 +332,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply, Button button1, Button button2, CancellationToken cancellation = default)
-        => ReplyAsync(client, message.Service.Id, message.User.Id, message.Id, reply, button1, button2, cancellation);
+        => ReplyAsync(client, message.Service.Id, PreferAddress(message.User), message.Id, reply, button1, button2, cancellation);
 
     /// <summary>
     /// Replies to a user message with additional interactive buttons.
@@ -319,7 +347,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the reply message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> ReplyAsync(this IWhatsAppClient client, UserMessage message, string reply, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
-        => ReplyAsync(client, message.Service.Id, message.User.Id, message.Id, reply, button1, button2, button3, cancellation);
+        => ReplyAsync(client, message.Service.Id, PreferAddress(message.User), message.Id, reply, button1, button2, button3, cancellation);
 
     /// <summary>
     /// Replies to the message a user reacted to.
@@ -335,8 +363,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(message.User.Id),
-            to = message.User.Id,
+            recipient_type = "individual",
+            to = ToField(PreferAddress(message.User)),
+            recipient = RecipientField(PreferAddress(message.User)),
             type = "text",
             context = new
             {
@@ -363,8 +392,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(message.User.Id),
-            to = message.User.Id,
+            recipient_type = "individual",
+            to = ToField(PreferAddress(message.User)),
+            recipient = RecipientField(PreferAddress(message.User)),
             type = "interactive",
             context = new
             {
@@ -403,8 +433,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(message.User.Id),
-            to = message.User.Id,
+            recipient_type = "individual",
+            to = ToField(PreferAddress(message.User)),
+            recipient = RecipientField(PreferAddress(message.User)),
             type = "interactive",
             context = new
             {
@@ -445,8 +476,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(message.User.Id),
-            to = message.User.Id,
+            recipient_type = "individual",
+            to = ToField(PreferAddress(message.User)),
+            recipient = RecipientField(PreferAddress(message.User)),
             type = "interactive",
             context = new
             {
@@ -481,7 +513,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#text-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, CancellationToken cancellation = default)
-        => SendAsync(client, source.Service.Id, source.User.Id, message, cancellation);
+        => SendAsync(client, source.Service.Id, PreferAddress(source.User), message, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
@@ -494,7 +526,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button, CancellationToken cancellation = default)
-        => SendAsync(client, source.Service.Id, source.User.Id, message, button, cancellation);
+        => SendAsync(client, source.Service.Id, PreferAddress(source.User), message, button, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
@@ -508,7 +540,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button1, Button button2, CancellationToken cancellation = default)
-        => SendAsync(client, source.Service.Id, source.User.Id, message, button1, button2, cancellation);
+        => SendAsync(client, source.Service.Id, PreferAddress(source.User), message, button1, button2, cancellation);
 
     /// <summary>
     /// Sends a text message a user given his incoming message, without making it a reply.
@@ -523,7 +555,7 @@ public static partial class WhatsAppClientExtensions
     /// <returns>The identifier of the sent message.</returns>
     /// <see cref="https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages/#interactive-object"/>
     public static Task<string?> SendAsync(this IWhatsAppClient client, Message source, string message, Button button1, Button button2, Button button3, CancellationToken cancellation = default)
-        => SendAsync(client, source.Service.Id, source.User.Id, message, button1, button2, button3, cancellation);
+        => SendAsync(client, source.Service.Id, PreferAddress(source.User), message, button1, button2, button3, cancellation);
 
     /// <summary>
     /// Sends a text message a user.
@@ -539,8 +571,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "text",
             text = new
             {
@@ -564,8 +597,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             interactive = new
             {
@@ -601,8 +635,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             interactive = new
             {
@@ -640,8 +675,9 @@ public static partial class WhatsAppClientExtensions
         {
             messaging_product = "whatsapp",
             preview_url = false,
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             interactive = new
             {
@@ -706,8 +742,9 @@ public static partial class WhatsAppClientExtensions
         => client.SendAsync(serviceId, new
         {
             messaging_product = "whatsapp",
-            recipient_type = RecipientType(userId),
-            to = userId,
+            recipient_type = "individual",
+            to = ToField(userId),
+            recipient = RecipientField(userId),
             type = "interactive",
             interactive = new
             {


### PR DESCRIPTION
## Summary

- **Root cause**: After BSUID support was introduced, send payloads used `recipient_type: "business_scoped_user_id"` and put the BSUID in `to`. Meta’s JSON schema only allows `recipient_type` values `individual`, `group`, or `null`, so the API returned OAuthException code 100.
- **Correct Cloud API shape** (per [Business-scoped user IDs](https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids/)):
  - `recipient_type` remains "individual"` for 1:1 messages
  - Phone numbers go in **`to`**
  - BSUIDs go in the newer **`recipient`** field
  - Both may be sent; **`to` takes precedence**
- **SDK fix**: All send helpers (`React`, text/interactive send/reply, templates, CTA, flows) now map identifiers correctly; when both phone and BSUID are known on a `User`, prefer phone so webhooks keep including numbers.
- **Default API version** bumped from `v22.0` → `v25.0` to match current Cloud API webhook/config practice.

## Test plan

- [x] `BsuidTests` (phone vs BSUID field mapping, PreferAddress)
- [x] `MetaOptionsTests` default ApiVersion assertion
- [x] Smoke send: reaction/text to a BSUID-only user → payload uses `recipient` + `recipient_type: individual`
- [x] Smoke send: user with both phone + BSUID → prefers `to` with phone
- [x] Phone-only users unchanged
