### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.netconfig
+++ b/.netconfig
@@ -120,9 +120,9 @@
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = dcd5f0a9a00a5b0c23d41a71dcc66ea41dc5f75d
+	sha = 3a758f47e8955c15a016b3db08f383781cbdee26
 
-	etag = 2cca66d8a1adbae24dc2efee53a55fa09949242eb35b86c5fd66425da18c6107
+	etag = 22005ab28676aa6d790171003057c81fe4ceec01251626385a3dcef3417ae3cd
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config


### PR DESCRIPTION
# devlooped/oss

- Fix PackageId assumption for static web assets https://github.com/devlooped/oss/commit/3a758f4