### PR TITLE
Fix GetFlowAssetsAsync pagination cursor wiring

### DIFF
--- a/src/WhatsApp/Flows/WhatsAppFlowsClientExtensions.cs
+++ b/src/WhatsApp/Flows/WhatsAppFlowsClientExtensions.cs
@@ -201,12 +201,12 @@ public static class WhatsAppFlowsClientExtensions
         do
         {
             var queryString = !string.IsNullOrEmpty(after) ? $"?after={Uri.EscapeDataString(after)}" : "";
-            var response = await http.GetAsync($"{flowId}/assets", cancellation);
+            var response = await http.GetAsync($"{flowId}/assets{queryString}", cancellation);
             response.EnsureSuccessStatusCode();
             var page = await response.Content.ReadFromJsonAsync<GetFlowAssetsResponse>(FlowsJsonContext.DefaultOptions, cancellation) ?? throw new InvalidOperationException("Invalid response");
 
-            foreach (var flow in page.Data ?? Enumerable.Empty<FlowAsset>())
-                yield return flow;
+            foreach (var asset in page.Data ?? Enumerable.Empty<FlowAsset>())
+                yield return asset;
 
             after = page.Paging?.Cursors?.After;
 


### PR DESCRIPTION
## Summary
- Wire the `after` cursor query string into `GET /{flow-id}/assets` requests so multi-page Flow asset lists are fetched correctly.
- Aligns with `GetFlowsAsync` paging and Meta Flows API response shape (`paging.cursors.after`).
- Rename loop variable from `flow` to `asset` for clarity.

## Test plan
- [ ] Review diff in `WhatsAppFlowsClientExtensions.GetFlowAssetsAsync`
- [ ] CI green
- [ ] (Optional) Call `GetFlowAssetsAsync` against a flow that returns `paging.cursors.after` and confirm subsequent pages are requested with `?after=...`
